### PR TITLE
feat: interactive TUI with column sorting and btop aesthetic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,23 +3,10 @@
 version = 4
 
 [[package]]
-name = "ansi-str"
-version = "0.9.0"
+name = "allocator-api2"
+version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "060de1453b69f46304b28274f382132f4e72c55637cf362920926a70d090890d"
-dependencies = [
- "ansitok",
-]
-
-[[package]]
-name = "ansitok"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0a8acea8c2f1c60f0a92a8cd26bf96ca97db56f10bbcab238bbe0cceba659ee"
-dependencies = [
- "nom",
- "vte",
-]
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "anstream"
@@ -57,7 +44,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -68,20 +55,35 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
-name = "arrayvec"
-version = "0.7.6"
+name = "bitflags"
+version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
 
 [[package]]
-name = "bytecount"
-version = "0.6.9"
+name = "cassowary"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "175812e0be2bccb6abe50bb8d566126198344f707e304f45c648fd8f2cc0365e"
+checksum = "df8670b8c7b9dae1793364eafadf7239c40d669904660c5960d74cfd80b46a53"
+
+[[package]]
+name = "castaway"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dec551ab6e7578819132c713a93c022a05d60159dc86e7a7050223577484c55a"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
+name = "cfg-if"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "clap"
@@ -130,19 +132,116 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
-name = "colored"
-version = "3.1.1"
+name = "compact_str"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
+checksum = "3b79c4069c6cad78e2e0cdfcbd26275770669fb39fd308a752dc110e83b9af32"
 dependencies = [
- "windows-sys",
+ "castaway",
+ "cfg-if",
+ "itoa",
+ "rustversion",
+ "ryu",
+ "static_assertions",
 ]
 
 [[package]]
-name = "fnv"
-version = "1.0.7"
+name = "crossterm"
+version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
+dependencies = [
+ "bitflags",
+ "crossterm_winapi",
+ "mio",
+ "parking_lot",
+ "rustix",
+ "signal-hook",
+ "signal-hook-mio",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm_winapi"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
+name = "darling"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
+dependencies = [
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "either"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash",
+]
 
 [[package]]
 name = "heck"
@@ -151,10 +250,53 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
+name = "indoc"
+version = "2.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79cf5c93f93228cf8efb3ba362535fb11199ac548a09ce117c9b1adc3030d706"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
+name = "instability"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "357b7205c6cd18dd2c86ed312d1e70add149aea98e7ef72b9fdf0270e555c11d"
+dependencies = [
+ "darling",
+ "indoc",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itoa"
+version = "1.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
 
 [[package]]
 name = "libc"
@@ -163,25 +305,45 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bcc35a38544a891a5f7c865aca548a982ccb3b8650a5b06d0fd33a10283c56fc"
 
 [[package]]
-name = "memchr"
-version = "2.8.0"
+name = "linux-raw-sys"
+version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
-name = "minimal-lexical"
-version = "0.2.1"
+name = "lock_api"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
-
-[[package]]
-name = "nom"
-version = "7.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
 dependencies = [
- "memchr",
- "minimal-lexical",
+ "scopeguard",
+]
+
+[[package]]
+name = "log"
+version = "0.4.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
+name = "lru"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
+dependencies = [
+ "hashbrown",
+]
+
+[[package]]
+name = "mio"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
+dependencies = [
+ "libc",
+ "log",
+ "wasi",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -191,49 +353,43 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
-name = "papergrid"
-version = "0.17.0"
+name = "parking_lot"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6978128c8b51d8f4080631ceb2302ab51e32cc6e8615f735ee2f83fd269ae3f1"
+checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
 dependencies = [
- "ansi-str",
- "ansitok",
- "bytecount",
- "fnv",
- "unicode-width",
+ "lock_api",
+ "parking_lot_core",
 ]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-link",
+]
+
+[[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "portview"
-version = "0.6.0"
+version = "1.0.0"
 dependencies = [
  "clap",
- "colored",
+ "crossterm",
  "libc",
- "tabled",
- "windows-sys",
-]
-
-[[package]]
-name = "proc-macro-error-attr2"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5"
-dependencies = [
- "proc-macro2",
- "quote",
-]
-
-[[package]]
-name = "proc-macro-error2"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802"
-dependencies = [
- "proc-macro-error-attr2",
- "proc-macro2",
- "quote",
- "syn",
+ "ratatui",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -255,10 +411,136 @@ dependencies = [
 ]
 
 [[package]]
+name = "ratatui"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eabd94c2f37801c20583fc49dd5cd6b0ba68c716787c2dd6ed18571e1e63117b"
+dependencies = [
+ "bitflags",
+ "cassowary",
+ "compact_str",
+ "crossterm",
+ "indoc",
+ "instability",
+ "itertools",
+ "lru",
+ "paste",
+ "strum",
+ "unicode-segmentation",
+ "unicode-truncate",
+ "unicode-width 0.2.0",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.5.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "rustix"
+version = "0.38.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "rustversion"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "ryu"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "signal-hook"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d881a16cf4426aa584979d30bd82cb33429027e42122b169753d6ef1085ed6e2"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
+
+[[package]]
+name = "signal-hook-mio"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b75a19a7a740b25bc7944bdee6172368f988763b744e3d4dfe753f6b4ece40cc"
+dependencies = [
+ "libc",
+ "mio",
+ "signal-hook",
+]
+
+[[package]]
+name = "signal-hook-registry"
+version = "1.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
+dependencies = [
+ "errno",
+ "libc",
+]
+
+[[package]]
+name = "smallvec"
+version = "1.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "strum"
+version = "0.26.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn",
+]
 
 [[package]]
 name = "syn"
@@ -272,52 +554,39 @@ dependencies = [
 ]
 
 [[package]]
-name = "tabled"
-version = "0.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e39a2ee1fbcd360805a771e1b300f78cc88fec7b8d3e2f71cd37bbf23e725c7d"
-dependencies = [
- "ansi-str",
- "ansitok",
- "papergrid",
- "tabled_derive",
- "testing_table",
-]
-
-[[package]]
-name = "tabled_derive"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ea5d1b13ca6cff1f9231ffd62f15eefd72543dab5e468735f1a456728a02846"
-dependencies = [
- "heck",
- "proc-macro-error2",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "testing_table"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f8daae29995a24f65619e19d8d31dea5b389f3d853d8bf297bbf607cd0014cc"
-dependencies = [
- "ansitok",
- "unicode-width",
-]
-
-[[package]]
 name = "unicode-ident"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
 
 [[package]]
-name = "unicode-width"
-version = "0.2.2"
+name = "unicode-segmentation"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
+checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
+
+[[package]]
+name = "unicode-truncate"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3644627a5af5fa321c95b9b235a72fd24cd29c648c2c379431e6628655627bf"
+dependencies = [
+ "itertools",
+ "unicode-segmentation",
+ "unicode-width 0.1.14",
+]
+
+[[package]]
+name = "unicode-width"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
+
+[[package]]
+name = "unicode-width"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd"
 
 [[package]]
 name = "utf8parse"
@@ -326,14 +595,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
-name = "vte"
-version = "0.14.1"
+name = "wasi"
+version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "231fdcd7ef3037e8330d8e17e61011a2c244126acc0a982f4040ac3f9f0bc077"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
 dependencies = [
- "arrayvec",
- "memchr",
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
 ]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-link"
@@ -343,9 +630,82 @@ checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
 ]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "portview"
-version = "0.6.0"
+version = "1.0.0"
 edition = "2021"
 description = "A diagnostic-first port viewer. See what's on your ports, then act on it."
 license = "MIT"
@@ -10,8 +10,8 @@ categories = ["command-line-utilities"]
 
 [dependencies]
 clap = { version = "4", features = ["derive"] }
-tabled = { version = "0.20", features = ["ansi"] }
-colored = "3"
+ratatui = "0.29"
+crossterm = "0.28"
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"

--- a/Formula/portview.rb
+++ b/Formula/portview.rb
@@ -1,7 +1,7 @@
 class Portview < Formula
   desc "See what's on your ports, then act on it"
   homepage "https://github.com/mapika/portview"
-  version "0.6.0"
+  version "1.0.0"
   license "MIT"
 
   on_linux do

--- a/README.md
+++ b/README.md
@@ -96,16 +96,45 @@ portview -k 3000 --force  # SIGKILL (Unix) / TerminateProcess (Windows)
 
 > **Note:** On Windows, `--kill` always force-terminates the process via `TerminateProcess`. There is no graceful shutdown equivalent to Unix SIGTERM.
 
-### Watch mode (live refresh)
+### Watch mode (interactive TUI)
 
 ```bash
-portview --watch            # refresh all ports every 1s
+portview --watch            # interactive TUI, refreshes every 1s
 portview -w 3000            # watch a specific port
 portview -w node            # watch filtered by process name
 portview -w --json          # streaming JSON, useful for piping
 ```
 
-The display refreshes every second. Ctrl+C exits cleanly.
+Watch mode opens an interactive TUI with a scrollable table, row selection, filtering, and kill confirmation.
+
+#### Keybindings
+
+**Table view:**
+
+| Key | Action |
+|-----|--------|
+| `j` / `↓` | Select next row |
+| `k` / `↑` | Select previous row |
+| `g` / `Home` | Jump to first row |
+| `G` / `End` | Jump to last row |
+| `Enter` | Inspect selected port (detail view) |
+| `d` | Kill process (SIGTERM, with confirmation) |
+| `D` | Force kill (SIGKILL, with confirmation) |
+| `/` | Enter filter mode |
+| `<` / `>` | Cycle sort column left / right |
+| `r` | Reverse sort direction |
+| `1`-`8` | Jump to column N (same column toggles direction) |
+| `a` | Toggle all/listening-only ports |
+| `q` / `Esc` | Quit |
+| `Ctrl+C` | Quit |
+
+**Detail view:** `Esc` to go back, `d`/`D` to kill, `q` to quit.
+
+**Filter mode:** Type to filter across all columns, `Enter` to apply, `Esc` to cancel and clear.
+
+**Kill popup:** `y`/`Enter` to confirm, `n`/`Esc` to cancel.
+
+Use `--watch --json` for non-interactive streaming JSON output (no TUI).
 
 ### JSON output
 

--- a/flake.nix
+++ b/flake.nix
@@ -15,7 +15,7 @@
         packages = rec {
           portview = pkgs.rustPlatform.buildRustPackage {
             pname = "portview";
-            version = "0.6.0";
+            version = "1.0.0";
 
             src = self;
 

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -1,0 +1,1123 @@
+use std::io;
+use std::time::{Duration, Instant};
+
+use crossterm::event::{self, Event, KeyCode, KeyEventKind, KeyModifiers};
+use crossterm::terminal::{
+    disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen,
+};
+use crossterm::ExecutableCommand;
+use ratatui::backend::CrosstermBackend;
+use ratatui::layout::{Alignment, Constraint, Rect};
+use ratatui::style::{Color, Modifier, Style};
+use ratatui::text::{Line, Span};
+use ratatui::widgets::{
+    Block, BorderType, Borders, Cell, Clear, Paragraph, Row, Table, TableState,
+};
+use ratatui::Terminal;
+
+#[cfg(target_os = "linux")]
+use crate::linux::get_port_infos;
+#[cfg(target_os = "macos")]
+use crate::macos::get_port_infos;
+#[cfg(target_os = "windows")]
+use crate::windows::get_port_infos;
+
+use crate::{
+    chrono_free_time, do_kill, format_addr, format_bytes, format_uptime, truncate_cmd, PortInfo,
+    StyleConfig,
+};
+
+// ── Sort types ───────────────────────────────────────────────────────
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+enum SortColumn {
+    Port,
+    Proto,
+    Pid,
+    User,
+    Process,
+    Uptime,
+    Mem,
+    Command,
+}
+
+impl SortColumn {
+    fn next(self) -> Self {
+        match self {
+            Self::Port => Self::Proto,
+            Self::Proto => Self::Pid,
+            Self::Pid => Self::User,
+            Self::User => Self::Process,
+            Self::Process => Self::Uptime,
+            Self::Uptime => Self::Mem,
+            Self::Mem => Self::Command,
+            Self::Command => Self::Port,
+        }
+    }
+
+    fn prev(self) -> Self {
+        match self {
+            Self::Port => Self::Command,
+            Self::Proto => Self::Port,
+            Self::Pid => Self::Proto,
+            Self::User => Self::Pid,
+            Self::Process => Self::User,
+            Self::Uptime => Self::Process,
+            Self::Mem => Self::Uptime,
+            Self::Command => Self::Mem,
+        }
+    }
+
+    fn label(self) -> &'static str {
+        match self {
+            Self::Port => "PORT",
+            Self::Proto => "PROTO",
+            Self::Pid => "PID",
+            Self::User => "USER",
+            Self::Process => "PROCESS",
+            Self::Uptime => "UPTIME",
+            Self::Mem => "MEM",
+            Self::Command => "COMMAND",
+        }
+    }
+
+    fn from_index(i: usize) -> Option<Self> {
+        match i {
+            0 => Some(Self::Port),
+            1 => Some(Self::Proto),
+            2 => Some(Self::Pid),
+            3 => Some(Self::User),
+            4 => Some(Self::Process),
+            5 => Some(Self::Uptime),
+            6 => Some(Self::Mem),
+            7 => Some(Self::Command),
+            _ => None,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+enum SortDirection {
+    Asc,
+    Desc,
+}
+
+impl SortDirection {
+    fn toggle(self) -> Self {
+        match self {
+            Self::Asc => Self::Desc,
+            Self::Desc => Self::Asc,
+        }
+    }
+
+    fn indicator(self) -> &'static str {
+        match self {
+            Self::Asc => " \u{25b2}",
+            Self::Desc => " \u{25bc}",
+        }
+    }
+}
+
+// ── Theme ────────────────────────────────────────────────────────────
+
+struct TuiTheme {
+    border: Style,
+    title: Style,
+    header_active: Style,
+    header_inactive: Style,
+    highlight_bg: Style,
+    highlight_symbol: &'static str,
+    footer_key: Style,
+    footer_text: Style,
+    status_ok: Style,
+    filter_accent: Style,
+    kill_border: Style,
+}
+
+impl TuiTheme {
+    fn default_btop() -> Self {
+        Self {
+            border: Style::default().fg(Color::Rgb(60, 70, 85)),
+            title: Style::default()
+                .fg(Color::Rgb(80, 200, 200))
+                .add_modifier(Modifier::BOLD),
+            header_active: Style::default()
+                .fg(Color::Rgb(100, 200, 200))
+                .add_modifier(Modifier::BOLD),
+            header_inactive: Style::default()
+                .fg(Color::Rgb(90, 90, 90))
+                .add_modifier(Modifier::BOLD),
+            highlight_bg: Style::default()
+                .bg(Color::Rgb(30, 40, 55))
+                .add_modifier(Modifier::BOLD),
+            highlight_symbol: "\u{2502} ",
+            footer_key: Style::default().fg(Color::Rgb(100, 200, 200)),
+            footer_text: Style::default().fg(Color::Rgb(130, 135, 140)),
+            status_ok: Style::default().fg(Color::Rgb(120, 200, 130)),
+            filter_accent: Style::default().fg(Color::Rgb(180, 130, 200)),
+            kill_border: Style::default().fg(Color::Rgb(200, 80, 80)),
+        }
+    }
+
+    fn no_color() -> Self {
+        Self {
+            border: Style::default(),
+            title: Style::default().add_modifier(Modifier::BOLD),
+            header_active: Style::default().add_modifier(Modifier::BOLD),
+            header_inactive: Style::default().add_modifier(Modifier::BOLD),
+            highlight_bg: Style::default().add_modifier(Modifier::BOLD),
+            highlight_symbol: "\u{2502} ",
+            footer_key: Style::default().add_modifier(Modifier::BOLD),
+            footer_text: Style::default().add_modifier(Modifier::DIM),
+            status_ok: Style::default(),
+            filter_accent: Style::default().add_modifier(Modifier::BOLD),
+            kill_border: Style::default(),
+        }
+    }
+}
+
+// ── App state ────────────────────────────────────────────────────────
+
+#[derive(PartialEq)]
+enum AppMode {
+    Table,
+    Detail,
+    FilterInput,
+}
+
+struct KillPopup {
+    pid: u32,
+    process_name: String,
+    port: u16,
+    force: bool,
+}
+
+pub struct App {
+    ports: Vec<PortInfo>,
+    table_state: TableState,
+    mode: AppMode,
+    show_all: bool,
+    filter_text: String,
+    popup: Option<KillPopup>,
+    target: Option<String>,
+    styles: StyleConfig,
+    theme: TuiTheme,
+    wide: bool,
+    default_force: bool,
+    should_quit: bool,
+    last_refresh: Instant,
+    detail_index: usize,
+    status_message: Option<(String, Instant)>,
+    sort_column: SortColumn,
+    sort_direction: SortDirection,
+}
+
+impl App {
+    fn new(
+        target: Option<&str>,
+        show_all: bool,
+        wide: bool,
+        force: bool,
+        no_color: bool,
+        styles: StyleConfig,
+    ) -> Self {
+        let theme = if no_color {
+            TuiTheme::no_color()
+        } else {
+            TuiTheme::default_btop()
+        };
+        let mut app = Self {
+            ports: Vec::new(),
+            table_state: TableState::default(),
+            mode: AppMode::Table,
+            show_all,
+            filter_text: String::new(),
+            popup: None,
+            target: target.map(|s| s.to_string()),
+            styles,
+            theme,
+            wide,
+            default_force: force,
+            should_quit: false,
+            last_refresh: Instant::now() - Duration::from_secs(2), // force immediate refresh
+            detail_index: 0,
+            status_message: None,
+            sort_column: SortColumn::Port,
+            sort_direction: SortDirection::Asc,
+        };
+        app.refresh_data();
+        if !app.sorted_ports().is_empty() {
+            app.table_state.select(Some(0));
+        }
+        app
+    }
+
+    fn refresh_data(&mut self) {
+        self.ports = get_port_infos(!self.show_all);
+        self.last_refresh = Instant::now();
+
+        // Clamp selection
+        let count = self.sorted_ports().len();
+        if count == 0 {
+            self.table_state.select(None);
+        } else if let Some(sel) = self.table_state.selected() {
+            if sel >= count {
+                self.table_state.select(Some(count - 1));
+            }
+        } else {
+            self.table_state.select(Some(0));
+        }
+    }
+
+    fn filtered_ports(&self) -> Vec<&PortInfo> {
+        let mut result: Vec<&PortInfo> = self.ports.iter().collect();
+
+        // Apply CLI target filter (process name search)
+        if let Some(ref target) = self.target {
+            if target.parse::<u16>().is_ok() {
+                let port: u16 = target.parse().unwrap();
+                result.retain(|i| i.port == port);
+            } else {
+                let t = target.to_lowercase();
+                result.retain(|i| {
+                    i.process_name.to_lowercase().contains(&t)
+                        || i.command.to_lowercase().contains(&t)
+                });
+            }
+        }
+
+        // Apply interactive filter
+        if !self.filter_text.is_empty() {
+            let f = self.filter_text.to_lowercase();
+            result.retain(|i| {
+                i.port.to_string().contains(&f)
+                    || i.protocol.to_lowercase().contains(&f)
+                    || i.pid.to_string().contains(&f)
+                    || i.process_name.to_lowercase().contains(&f)
+                    || i.command.to_lowercase().contains(&f)
+                    || i.user.to_lowercase().contains(&f)
+            });
+        }
+
+        result
+    }
+
+    fn sorted_ports(&self) -> Vec<&PortInfo> {
+        let mut result = self.filtered_ports();
+        let dir = self.sort_direction;
+        result.sort_by(|a, b| {
+            let cmp = match self.sort_column {
+                SortColumn::Port => a.port.cmp(&b.port),
+                SortColumn::Proto => a.protocol.to_lowercase().cmp(&b.protocol.to_lowercase()),
+                SortColumn::Pid => a.pid.cmp(&b.pid),
+                SortColumn::User => a.user.to_lowercase().cmp(&b.user.to_lowercase()),
+                SortColumn::Process => a
+                    .process_name
+                    .to_lowercase()
+                    .cmp(&b.process_name.to_lowercase()),
+                SortColumn::Uptime => {
+                    // Earlier start_time = longer uptime = should sort first in Asc
+                    // None sorts last
+                    match (a.start_time, b.start_time) {
+                        (Some(sa), Some(sb)) => sa.cmp(&sb),
+                        (Some(_), None) => std::cmp::Ordering::Less,
+                        (None, Some(_)) => std::cmp::Ordering::Greater,
+                        (None, None) => std::cmp::Ordering::Equal,
+                    }
+                }
+                SortColumn::Mem => a.memory_bytes.cmp(&b.memory_bytes),
+                SortColumn::Command => a.command.to_lowercase().cmp(&b.command.to_lowercase()),
+            };
+            if dir == SortDirection::Desc {
+                cmp.reverse()
+            } else {
+                cmp
+            }
+        });
+        result
+    }
+
+    fn selected_port(&self) -> Option<&PortInfo> {
+        let ports = self.sorted_ports();
+        self.table_state
+            .selected()
+            .and_then(|i| ports.get(i).copied())
+    }
+
+    fn select_next(&mut self) {
+        let count = self.sorted_ports().len();
+        if count == 0 {
+            return;
+        }
+        let i = self.table_state.selected().unwrap_or(0);
+        self.table_state.select(Some((i + 1).min(count - 1)));
+    }
+
+    fn select_prev(&mut self) {
+        let count = self.sorted_ports().len();
+        if count == 0 {
+            return;
+        }
+        let i = self.table_state.selected().unwrap_or(0);
+        self.table_state.select(Some(i.saturating_sub(1)));
+    }
+
+    fn select_first(&mut self) {
+        if !self.sorted_ports().is_empty() {
+            self.table_state.select(Some(0));
+        }
+    }
+
+    fn select_last(&mut self) {
+        let count = self.sorted_ports().len();
+        if count > 0 {
+            self.table_state.select(Some(count - 1));
+        }
+    }
+}
+
+// ── Rendering ────────────────────────────────────────────────────────
+
+fn build_title_line(app: &App) -> Line<'_> {
+    let port_count = app.sorted_ports().len();
+    let mut spans = vec![
+        Span::styled(" portview", app.theme.title),
+        Span::styled("  ", app.theme.footer_text),
+        Span::styled(
+            format!(
+                "{} port{}",
+                port_count,
+                if port_count == 1 { "" } else { "s" }
+            ),
+            app.theme.title,
+        ),
+        Span::raw(" "),
+    ];
+
+    if app.show_all {
+        spans.push(Span::styled(
+            "(all) ",
+            Style::default().fg(Color::Rgb(220, 180, 80)),
+        ));
+    }
+
+    if !app.filter_text.is_empty() {
+        spans.push(Span::styled(
+            format!("[filter: {}] ", app.filter_text),
+            app.theme.filter_accent,
+        ));
+    }
+
+    if let Some(ref target) = app.target {
+        spans.push(Span::styled(
+            format!("[target: {}] ", target),
+            app.theme.footer_text,
+        ));
+    }
+
+    if let Some((ref msg, at)) = app.status_message {
+        if at.elapsed() < Duration::from_secs(3) {
+            spans.push(Span::styled(msg.clone(), app.theme.status_ok));
+            spans.push(Span::raw(" "));
+        }
+    }
+
+    Line::from(spans)
+}
+
+fn build_footer_line(app: &App) -> Line<'_> {
+    let time = chrono_free_time();
+
+    if app.mode == AppMode::FilterInput {
+        Line::from(vec![
+            Span::styled(" /", app.theme.filter_accent),
+            Span::raw(&app.filter_text),
+            Span::styled("\u{2588}", app.theme.filter_accent),
+            Span::styled("  Enter", app.theme.footer_key),
+            Span::styled(" apply  ", app.theme.footer_text),
+            Span::styled("Esc", app.theme.footer_key),
+            Span::styled(" cancel ", app.theme.footer_text),
+        ])
+    } else {
+        Line::from(vec![
+            Span::styled(" j/k", app.theme.footer_key),
+            Span::styled(" move  ", app.theme.footer_text),
+            Span::styled("Enter", app.theme.footer_key),
+            Span::styled(" inspect  ", app.theme.footer_text),
+            Span::styled("d/D", app.theme.footer_key),
+            Span::styled(" kill  ", app.theme.footer_text),
+            Span::styled("/", app.theme.footer_key),
+            Span::styled(" filter  ", app.theme.footer_text),
+            Span::styled("</>/r", app.theme.footer_key),
+            Span::styled(" sort  ", app.theme.footer_text),
+            Span::styled("a", app.theme.footer_key),
+            Span::styled(" all  ", app.theme.footer_text),
+            Span::styled("q", app.theme.footer_key),
+            Span::styled(" quit  ", app.theme.footer_text),
+            Span::styled(format!("Updated {} ", time), app.theme.footer_text),
+        ])
+    }
+}
+
+fn render(frame: &mut ratatui::Frame, app: &mut App) {
+    let area = frame.area();
+
+    let title_line = build_title_line(app);
+    let footer_line = build_footer_line(app);
+
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_type(BorderType::Rounded)
+        .border_style(app.theme.border)
+        .title_top(title_line)
+        .title_bottom(footer_line);
+
+    let inner = block.inner(area);
+    frame.render_widget(block, area);
+
+    match app.mode {
+        AppMode::Table | AppMode::FilterInput => render_table(frame, app, inner),
+        AppMode::Detail => render_detail(frame, app, inner),
+    }
+
+    // Popup overlay
+    if app.popup.is_some() {
+        render_kill_popup(frame, app, area);
+    }
+}
+
+fn render_table(frame: &mut ratatui::Frame, app: &mut App, area: Rect) {
+    let ports = app.sorted_ports();
+    let wide = app.wide;
+    let cmd_width = if wide {
+        usize::MAX
+    } else {
+        let total = area.width as usize;
+        total.saturating_sub(77).max(10)
+    };
+
+    let columns = [
+        SortColumn::Port,
+        SortColumn::Proto,
+        SortColumn::Pid,
+        SortColumn::User,
+        SortColumn::Process,
+        SortColumn::Uptime,
+        SortColumn::Mem,
+        SortColumn::Command,
+    ];
+
+    let header_cells: Vec<Cell> = columns
+        .iter()
+        .map(|col| {
+            let is_active = *col == app.sort_column;
+            let label = if is_active {
+                format!("{}{}", col.label(), app.sort_direction.indicator())
+            } else {
+                col.label().to_string()
+            };
+            let style = if is_active {
+                app.theme.header_active
+            } else {
+                app.theme.header_inactive
+            };
+            Cell::from(label).style(style)
+        })
+        .collect();
+    let header = Row::new(header_cells).height(1);
+
+    let rows: Vec<Row> = ports
+        .iter()
+        .map(|info| {
+            let cmd = if wide {
+                info.command.clone()
+            } else {
+                truncate_cmd(&info.command, cmd_width)
+            };
+            Row::new(vec![
+                Cell::from(info.port.to_string()).style(app.styles.port),
+                Cell::from(info.protocol.clone()).style(app.styles.proto),
+                Cell::from(info.pid.to_string()).style(app.styles.pid),
+                Cell::from(info.user.clone()).style(app.styles.user),
+                Cell::from(info.process_name.clone()).style(app.styles.process),
+                Cell::from(format_uptime(info.start_time)).style(app.styles.uptime),
+                Cell::from(format_bytes(info.memory_bytes)).style(app.styles.mem),
+                Cell::from(cmd).style(app.styles.command),
+            ])
+        })
+        .collect();
+
+    let widths = [
+        Constraint::Length(6),
+        Constraint::Length(5),
+        Constraint::Length(7),
+        Constraint::Length(8),
+        Constraint::Length(10),
+        Constraint::Length(8),
+        Constraint::Length(8),
+        Constraint::Fill(1),
+    ];
+
+    let table = Table::new(rows, widths)
+        .header(header)
+        .row_highlight_style(app.theme.highlight_bg)
+        .highlight_symbol(app.theme.highlight_symbol);
+
+    frame.render_stateful_widget(table, area, &mut app.table_state);
+}
+
+fn render_detail(frame: &mut ratatui::Frame, app: &App, area: Rect) {
+    let ports = app.sorted_ports();
+    let info = match ports.get(app.detail_index) {
+        Some(i) => i,
+        None => {
+            let p =
+                Paragraph::new("Port no longer available.").style(Style::default().fg(Color::Red));
+            frame.render_widget(p, area);
+            return;
+        }
+    };
+
+    let bind_str = format!("{}:{}", format_addr(&info.local_addr), info.port);
+    let uptime = format_uptime(info.start_time);
+
+    let title_line = Line::from(vec![
+        Span::styled("Port ", app.theme.title),
+        Span::styled(info.port.to_string(), app.theme.title),
+        Span::styled(format!(" ({}) ", info.protocol), app.theme.footer_text),
+        Span::styled("\u{2014} ", app.theme.footer_text),
+        Span::styled(&info.process_name, app.theme.status_ok),
+        Span::styled(
+            format!(" (PID {})", info.pid),
+            Style::default().fg(Color::Rgb(220, 180, 80)),
+        ),
+    ]);
+
+    let label_style = app.theme.footer_text;
+
+    let rows = vec![
+        ("Bind:", bind_str),
+        ("Command:", info.command.clone()),
+        ("User:", info.user.clone()),
+        ("Started:", format!("{} ago", uptime)),
+        ("Memory:", format_bytes(info.memory_bytes)),
+        ("CPU time:", format!("{:.1}s", info.cpu_seconds)),
+        ("Children:", info.children.to_string()),
+        ("State:", info.state.to_string()),
+    ];
+
+    let mut lines = vec![Line::default(), title_line, Line::default()];
+    for (label, value) in &rows {
+        lines.push(Line::from(vec![
+            Span::raw("  "),
+            Span::styled(format!("{:<10}", label), label_style),
+            Span::raw(value),
+        ]));
+    }
+    lines.push(Line::default());
+    lines.push(Line::from(vec![
+        Span::styled("  Esc", app.theme.footer_key),
+        Span::styled(" back  ", app.theme.footer_text),
+        Span::styled("d", app.theme.footer_key),
+        Span::styled(" kill  ", app.theme.footer_text),
+        Span::styled("D", app.theme.footer_key),
+        Span::styled(" force kill  ", app.theme.footer_text),
+        Span::styled("q", app.theme.footer_key),
+        Span::styled(" quit", app.theme.footer_text),
+    ]));
+
+    let paragraph = Paragraph::new(lines);
+    frame.render_widget(paragraph, area);
+}
+
+fn render_kill_popup(frame: &mut ratatui::Frame, app: &App, area: Rect) {
+    let popup = match &app.popup {
+        Some(p) => p,
+        None => return,
+    };
+
+    let signal = if popup.force { "SIGKILL" } else { "SIGTERM" };
+
+    let text = vec![
+        Line::default(),
+        Line::from(vec![
+            Span::raw("  Kill "),
+            Span::styled(&popup.process_name, app.theme.status_ok),
+            Span::raw(format!(" (PID {}) on port {}?", popup.pid, popup.port)),
+        ]),
+        Line::from(vec![Span::raw(format!("  Signal: {}", signal))]),
+        Line::default(),
+        Line::from(vec![
+            Span::raw("  "),
+            Span::styled("y/Enter", app.theme.footer_key),
+            Span::styled(" confirm   ", app.theme.footer_text),
+            Span::styled("n/Esc", app.theme.footer_key),
+            Span::styled(" cancel", app.theme.footer_text),
+        ]),
+        Line::default(),
+    ];
+
+    let popup_width = 50u16.min(area.width.saturating_sub(4));
+    let popup_height = 6u16.min(area.height.saturating_sub(4));
+    let x = (area.width.saturating_sub(popup_width)) / 2;
+    let y = (area.height.saturating_sub(popup_height)) / 2;
+    let popup_area = Rect::new(x, y, popup_width, popup_height);
+
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_type(BorderType::Rounded)
+        .border_style(app.theme.kill_border)
+        .title(" Kill Process ")
+        .title_alignment(Alignment::Center)
+        .title_style(app.theme.kill_border.add_modifier(Modifier::BOLD));
+
+    frame.render_widget(Clear, popup_area);
+    let paragraph = Paragraph::new(text).block(block);
+    frame.render_widget(paragraph, popup_area);
+}
+
+// ── Event handling ───────────────────────────────────────────────────
+
+fn handle_key(app: &mut App, code: KeyCode, modifiers: KeyModifiers) {
+    // Global: Ctrl+C always quits
+    if modifiers.contains(KeyModifiers::CONTROL) && code == KeyCode::Char('c') {
+        app.should_quit = true;
+        return;
+    }
+
+    // Kill popup takes priority
+    if app.popup.is_some() {
+        handle_popup_key(app, code);
+        return;
+    }
+
+    match app.mode {
+        AppMode::Table => handle_table_key(app, code),
+        AppMode::Detail => handle_detail_key(app, code),
+        AppMode::FilterInput => handle_filter_key(app, code),
+    }
+}
+
+fn handle_table_key(app: &mut App, code: KeyCode) {
+    match code {
+        KeyCode::Char('q') | KeyCode::Esc => app.should_quit = true,
+        KeyCode::Char('j') | KeyCode::Down => app.select_next(),
+        KeyCode::Char('k') | KeyCode::Up => app.select_prev(),
+        KeyCode::Char('g') | KeyCode::Home => app.select_first(),
+        KeyCode::Char('G') | KeyCode::End => app.select_last(),
+        KeyCode::Enter => {
+            if let Some(idx) = app.table_state.selected() {
+                app.detail_index = idx;
+                app.mode = AppMode::Detail;
+            }
+        }
+        KeyCode::Char('d') => {
+            if let Some(info) = app.selected_port().cloned() {
+                app.popup = Some(KillPopup {
+                    pid: info.pid,
+                    process_name: info.process_name.clone(),
+                    port: info.port,
+                    force: app.default_force,
+                });
+            }
+        }
+        KeyCode::Char('D') => {
+            if let Some(info) = app.selected_port().cloned() {
+                app.popup = Some(KillPopup {
+                    pid: info.pid,
+                    process_name: info.process_name.clone(),
+                    port: info.port,
+                    force: true,
+                });
+            }
+        }
+        KeyCode::Char('/') => {
+            app.mode = AppMode::FilterInput;
+            app.filter_text.clear();
+        }
+        KeyCode::Char('a') => {
+            app.show_all = !app.show_all;
+            app.refresh_data();
+        }
+        KeyCode::Char('<') => {
+            app.sort_column = app.sort_column.prev();
+        }
+        KeyCode::Char('>') => {
+            app.sort_column = app.sort_column.next();
+        }
+        KeyCode::Char('r') => {
+            app.sort_direction = app.sort_direction.toggle();
+        }
+        KeyCode::Char(c @ '1'..='8') => {
+            let idx = (c as usize) - ('1' as usize);
+            if let Some(col) = SortColumn::from_index(idx) {
+                if app.sort_column == col {
+                    app.sort_direction = app.sort_direction.toggle();
+                } else {
+                    app.sort_column = col;
+                    app.sort_direction = SortDirection::Asc;
+                }
+            }
+        }
+        _ => {}
+    }
+}
+
+fn handle_detail_key(app: &mut App, code: KeyCode) {
+    match code {
+        KeyCode::Esc => app.mode = AppMode::Table,
+        KeyCode::Char('q') => app.should_quit = true,
+        KeyCode::Char('d') => {
+            let ports = app.sorted_ports();
+            if let Some(info) = ports.get(app.detail_index) {
+                app.popup = Some(KillPopup {
+                    pid: info.pid,
+                    process_name: info.process_name.clone(),
+                    port: info.port,
+                    force: app.default_force,
+                });
+            }
+        }
+        KeyCode::Char('D') => {
+            let ports = app.sorted_ports();
+            if let Some(info) = ports.get(app.detail_index) {
+                app.popup = Some(KillPopup {
+                    pid: info.pid,
+                    process_name: info.process_name.clone(),
+                    port: info.port,
+                    force: true,
+                });
+            }
+        }
+        _ => {}
+    }
+}
+
+fn handle_filter_key(app: &mut App, code: KeyCode) {
+    match code {
+        KeyCode::Enter => {
+            app.mode = AppMode::Table;
+            // Clamp selection after filter applied
+            let count = app.sorted_ports().len();
+            if count == 0 {
+                app.table_state.select(None);
+            } else {
+                app.table_state.select(Some(0));
+            }
+        }
+        KeyCode::Esc => {
+            app.filter_text.clear();
+            app.mode = AppMode::Table;
+            // Reselect after clearing filter
+            let count = app.sorted_ports().len();
+            if count > 0 && app.table_state.selected().is_none() {
+                app.table_state.select(Some(0));
+            }
+        }
+        KeyCode::Backspace => {
+            app.filter_text.pop();
+        }
+        KeyCode::Char(c) => {
+            app.filter_text.push(c);
+        }
+        _ => {}
+    }
+}
+
+fn handle_popup_key(app: &mut App, code: KeyCode) {
+    match code {
+        KeyCode::Char('y') | KeyCode::Enter => {
+            if let Some(popup) = app.popup.take() {
+                do_kill(popup.pid, popup.force);
+                let signal = if popup.force { "SIGKILL" } else { "SIGTERM" };
+                app.status_message = Some((
+                    format!("Sent {} to PID {}", signal, popup.pid),
+                    Instant::now(),
+                ));
+                // Refresh immediately to reflect killed process
+                app.refresh_data();
+            }
+        }
+        KeyCode::Char('n') | KeyCode::Esc => {
+            app.popup = None;
+        }
+        _ => {}
+    }
+}
+
+// ── Main entry point ─────────────────────────────────────────────────
+
+pub fn run_tui(
+    target: Option<&str>,
+    show_all: bool,
+    wide: bool,
+    force: bool,
+    no_color: bool,
+    styles: StyleConfig,
+) -> io::Result<()> {
+    // Setup terminal
+    enable_raw_mode()?;
+    let mut stdout = io::stdout();
+    stdout.execute(EnterAlternateScreen)?;
+
+    let backend = CrosstermBackend::new(stdout);
+    let mut terminal = Terminal::new(backend)?;
+    terminal.clear()?;
+
+    let mut app = App::new(target, show_all, wide, force, no_color, styles);
+
+    let tick_rate = Duration::from_secs(1);
+
+    loop {
+        terminal.draw(|frame| render(frame, &mut app))?;
+
+        if app.should_quit {
+            break;
+        }
+
+        // Refresh data every tick
+        if app.last_refresh.elapsed() >= tick_rate {
+            app.refresh_data();
+        }
+
+        // Wait for events with timeout to next tick
+        let remaining = tick_rate
+            .checked_sub(app.last_refresh.elapsed())
+            .unwrap_or(Duration::ZERO);
+
+        if event::poll(remaining)? {
+            if let Event::Key(key) = event::read()? {
+                // Only handle Press events (not Release/Repeat)
+                if key.kind == KeyEventKind::Press {
+                    handle_key(&mut app, key.code, key.modifiers);
+                }
+            }
+        }
+    }
+
+    // Restore terminal
+    disable_raw_mode()?;
+    terminal.backend_mut().execute(LeaveAlternateScreen)?;
+    terminal.show_cursor()?;
+
+    Ok(())
+}
+
+// ── Tests ────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::net::{IpAddr, Ipv4Addr};
+    use std::time::SystemTime;
+
+    fn make_port_info(port: u16, name: &str, cmd: &str) -> PortInfo {
+        PortInfo {
+            port,
+            protocol: "TCP".to_string(),
+            pid: port as u32 * 100,
+            process_name: name.to_string(),
+            command: cmd.to_string(),
+            user: "test".to_string(),
+            state: crate::TcpState::Listen,
+            memory_bytes: 1024 * 1024,
+            cpu_seconds: 1.0,
+            start_time: Some(SystemTime::now() - Duration::from_secs(60)),
+            children: 0,
+            local_addr: IpAddr::V4(Ipv4Addr::UNSPECIFIED),
+        }
+    }
+
+    fn make_test_app(ports: Vec<PortInfo>) -> App {
+        App {
+            ports,
+            table_state: TableState::default(),
+            mode: AppMode::Table,
+            show_all: false,
+            filter_text: String::new(),
+            popup: None,
+            target: None,
+            styles: StyleConfig::no_color(),
+            theme: TuiTheme::no_color(),
+            wide: false,
+            default_force: false,
+            should_quit: false,
+            last_refresh: Instant::now(),
+            detail_index: 0,
+            status_message: None,
+            sort_column: SortColumn::Port,
+            sort_direction: SortDirection::Asc,
+        }
+    }
+
+    #[test]
+    fn filtered_ports_no_filter() {
+        let mut app = make_test_app(vec![
+            make_port_info(3000, "node", "next dev"),
+            make_port_info(5432, "postgres", "postgres"),
+        ]);
+        assert_eq!(app.filtered_ports().len(), 2);
+
+        // Filter by text
+        app.filter_text = "node".to_string();
+        let filtered = app.filtered_ports();
+        assert_eq!(filtered.len(), 1);
+        assert_eq!(filtered[0].port, 3000);
+    }
+
+    #[test]
+    fn filtered_ports_by_port_number() {
+        let mut app = make_test_app(vec![
+            make_port_info(3000, "node", "next dev"),
+            make_port_info(5432, "postgres", "postgres"),
+        ]);
+
+        app.filter_text = "5432".to_string();
+        let filtered = app.filtered_ports();
+        assert_eq!(filtered.len(), 1);
+        assert_eq!(filtered[0].port, 5432);
+    }
+
+    #[test]
+    fn filtered_ports_with_target() {
+        let mut app = make_test_app(vec![
+            make_port_info(3000, "node", "next dev"),
+            make_port_info(5432, "postgres", "postgres"),
+            make_port_info(8080, "node", "express"),
+        ]);
+        app.target = Some("node".to_string());
+
+        let filtered = app.filtered_ports();
+        assert_eq!(filtered.len(), 2);
+        assert!(filtered.iter().all(|p| p.process_name == "node"));
+    }
+
+    #[test]
+    fn filtered_ports_target_port_number() {
+        let mut app = make_test_app(vec![
+            make_port_info(3000, "node", "next dev"),
+            make_port_info(5432, "postgres", "postgres"),
+        ]);
+        app.target = Some("3000".to_string());
+
+        let filtered = app.filtered_ports();
+        assert_eq!(filtered.len(), 1);
+        assert_eq!(filtered[0].port, 3000);
+    }
+
+    #[test]
+    fn filtered_ports_case_insensitive() {
+        let mut app = make_test_app(vec![
+            make_port_info(3000, "Node", "Next dev"),
+            make_port_info(5432, "postgres", "postgres"),
+        ]);
+
+        app.filter_text = "NODE".to_string();
+        let filtered = app.filtered_ports();
+        assert_eq!(filtered.len(), 1);
+        assert_eq!(filtered[0].port, 3000);
+    }
+
+    #[test]
+    fn filtered_ports_empty_result() {
+        let mut app = make_test_app(vec![make_port_info(3000, "node", "next dev")]);
+
+        app.filter_text = "nonexistent".to_string();
+        assert!(app.filtered_ports().is_empty());
+    }
+
+    #[test]
+    fn sorted_ports_by_port_asc() {
+        let app = make_test_app(vec![
+            make_port_info(8080, "node", "express"),
+            make_port_info(3000, "node", "next dev"),
+            make_port_info(5432, "postgres", "postgres"),
+        ]);
+        let sorted = app.sorted_ports();
+        assert_eq!(sorted[0].port, 3000);
+        assert_eq!(sorted[1].port, 5432);
+        assert_eq!(sorted[2].port, 8080);
+    }
+
+    #[test]
+    fn sorted_ports_by_port_desc() {
+        let mut app = make_test_app(vec![
+            make_port_info(3000, "node", "next dev"),
+            make_port_info(8080, "node", "express"),
+            make_port_info(5432, "postgres", "postgres"),
+        ]);
+        app.sort_direction = SortDirection::Desc;
+        let sorted = app.sorted_ports();
+        assert_eq!(sorted[0].port, 8080);
+        assert_eq!(sorted[1].port, 5432);
+        assert_eq!(sorted[2].port, 3000);
+    }
+
+    #[test]
+    fn sorted_ports_by_process() {
+        let mut app = make_test_app(vec![
+            make_port_info(3000, "node", "next dev"),
+            make_port_info(5432, "postgres", "postgres"),
+            make_port_info(6379, "redis", "redis-server"),
+        ]);
+        app.sort_column = SortColumn::Process;
+        let sorted = app.sorted_ports();
+        assert_eq!(sorted[0].process_name, "node");
+        assert_eq!(sorted[1].process_name, "postgres");
+        assert_eq!(sorted[2].process_name, "redis");
+    }
+
+    #[test]
+    fn sorted_ports_by_mem() {
+        let mut p1 = make_port_info(3000, "node", "next dev");
+        let mut p2 = make_port_info(5432, "postgres", "postgres");
+        let mut p3 = make_port_info(6379, "redis", "redis-server");
+        p1.memory_bytes = 200 * 1024 * 1024;
+        p2.memory_bytes = 50 * 1024 * 1024;
+        p3.memory_bytes = 10 * 1024 * 1024;
+
+        let mut app = make_test_app(vec![p1, p2, p3]);
+        app.sort_column = SortColumn::Mem;
+        app.sort_direction = SortDirection::Desc;
+        let sorted = app.sorted_ports();
+        assert_eq!(sorted[0].port, 3000); // highest mem
+        assert_eq!(sorted[1].port, 5432);
+        assert_eq!(sorted[2].port, 6379); // lowest mem
+    }
+
+    #[test]
+    fn sorted_ports_uptime_none_sorts_last() {
+        let mut p1 = make_port_info(3000, "node", "next dev");
+        let mut p2 = make_port_info(5432, "postgres", "postgres");
+        p1.start_time = None;
+        p2.start_time = Some(SystemTime::now() - Duration::from_secs(3600));
+
+        let mut app = make_test_app(vec![p1, p2]);
+        app.sort_column = SortColumn::Uptime;
+        let sorted = app.sorted_ports();
+        // p2 has a start_time, p1 has None → p2 first
+        assert_eq!(sorted[0].port, 5432);
+        assert_eq!(sorted[1].port, 3000);
+    }
+
+    #[test]
+    fn sort_column_cycle() {
+        let col = SortColumn::Port;
+        assert_eq!(col.next(), SortColumn::Proto);
+        assert_eq!(col.prev(), SortColumn::Command);
+        assert_eq!(SortColumn::Command.next(), SortColumn::Port);
+    }
+
+    #[test]
+    fn sort_direction_toggle() {
+        assert_eq!(SortDirection::Asc.toggle(), SortDirection::Desc);
+        assert_eq!(SortDirection::Desc.toggle(), SortDirection::Asc);
+    }
+
+    #[test]
+    fn sort_column_from_index() {
+        assert_eq!(SortColumn::from_index(0), Some(SortColumn::Port));
+        assert_eq!(SortColumn::from_index(7), Some(SortColumn::Command));
+        assert_eq!(SortColumn::from_index(8), None);
+    }
+}


### PR DESCRIPTION
## Summary
- Replace tabled/colored with ratatui/crossterm for a full interactive TUI in watch mode
- Add column sorting (`<`/`>`/`r`/`1-8` keys) with sort indicators in header
- Apply btop-inspired soft RGB color palette with rounded borders and teal accents
- Add `StyleConfig::btop_default()` for TUI-specific data colors (activates when `PORTVIEW_COLORS` is not set)
- Bump version to 1.0.0

## What's new

**TUI features:** scrollable table, row selection, detail view, kill confirmation popup, live filtering, column sorting

**Sort keybindings:**
| Key | Action |
|-----|--------|
| `<` / `>` | Cycle sort column left / right |
| `r` | Reverse sort direction |
| `1`-`8` | Jump to column N (same column toggles direction) |

**Visual redesign:** single rounded bordered block layout, teal accent palette, sort-aware header with ▲/▼ indicators, themed kill popup

## Test plan
- [x] `cargo test` — 74 tests pass (7 new sort tests)
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check` — formatted
- [ ] Manual: `cargo run -- -w` — bordered layout, soft colors, sort keys work
- [ ] Manual: `cargo run -- -w --no-color` — functional without colors
- [ ] Manual: `PORTVIEW_COLORS="port=red" cargo run -- -w` — user override respected

🤖 Generated with [Claude Code](https://claude.com/claude-code)