### PR TITLE
fix: right-align UPTIME/MEM, hide inaccessible processes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -383,7 +383,7 @@ checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "portview"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "clap",
  "crossterm",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "portview"
-version = "1.0.0"
+version = "1.0.1"
 edition = "2021"
 description = "A diagnostic-first port viewer. See what's on your ports, then act on it."
 license = "MIT"

--- a/flake.nix
+++ b/flake.nix
@@ -15,7 +15,7 @@
         packages = rec {
           portview = pkgs.rustPlatform.buildRustPackage {
             pname = "portview";
-            version = "1.0.0";
+            version = "1.0.1";
 
             src = self;
 

--- a/src/linux.rs
+++ b/src/linux.rs
@@ -312,6 +312,9 @@ pub fn get_port_infos(filter_listening: bool) -> Vec<PortInfo> {
         });
     }
 
+    // Drop entries where we couldn't read process details (other user's process without sudo)
+    infos.retain(|i| !i.process_name.is_empty());
+
     // Sort by port number, then protocol, then pid (pid needed for dedup_by adjacency)
     infos.sort_by(|a, b| {
         a.port

--- a/src/macos.rs
+++ b/src/macos.rs
@@ -518,6 +518,9 @@ pub fn get_port_infos(filter_listening: bool) -> Vec<PortInfo> {
         }
     }
 
+    // Drop entries where we couldn't read process details (other user's process without sudo)
+    infos.retain(|i| !i.process_name.is_empty());
+
     // Sort by port number, then protocol, then pid (pid needed for dedup_by adjacency)
     infos.sort_by(|a, b| {
         a.port

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -540,8 +540,10 @@ fn render_table(frame: &mut ratatui::Frame, app: &mut App, area: Rect) {
                 Cell::from(info.pid.to_string()).style(app.styles.pid),
                 Cell::from(info.user.clone()).style(app.styles.user),
                 Cell::from(info.process_name.clone()).style(app.styles.process),
-                Cell::from(format_uptime(info.start_time)).style(app.styles.uptime),
-                Cell::from(format_bytes(info.memory_bytes)).style(app.styles.mem),
+                Cell::from(Line::from(format_uptime(info.start_time)).alignment(Alignment::Right))
+                    .style(app.styles.uptime),
+                Cell::from(Line::from(format_bytes(info.memory_bytes)).alignment(Alignment::Right))
+                    .style(app.styles.mem),
                 Cell::from(cmd).style(app.styles.command),
             ])
         })

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -531,6 +531,9 @@ pub fn get_port_infos(filter_listening: bool) -> Vec<PortInfo> {
         }
     }
 
+    // Drop entries where we couldn't read process details (other user's process without elevated privileges)
+    infos.retain(|i| !i.process_name.is_empty());
+
     // Sort by port number, then protocol, then pid (pid needed for dedup_by adjacency)
     infos.sort_by(|a, b| {
         a.port


### PR DESCRIPTION
## Summary
- Right-align UPTIME and MEM columns in TUI table for cleaner numeric readability
- Hide entries where process details are unreadable (other users' processes without sudo) across all platforms — these showed a port number but no useful info
- Bump version to 1.0.1

## Test plan
- [x] `cargo test` — 74 tests pass
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [ ] Manual: verify UPTIME/MEM right-aligned in `cargo run -- -w`
- [ ] Manual: verify other users' ports hidden without sudo, visible with sudo

🤖 Generated with [Claude Code](https://claude.com/claude-code)