### PR TITLE
Prepare 2.0.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,11 @@ name: Release
 on:
   push:
     tags:
-      - 'v*'
+      # Full versions only. The GitHub Action published from this repo needs a
+      # moving major tag (v2) that users pin with `uses: mapika/portview@v2`,
+      # and a bare 'v*' pattern would fire a whole release build every time that
+      # tag was repointed.
+      - 'v*.*.*'
 
 permissions:
   contents: write

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,57 @@
+# Changelog
+
+## 2.0.0
+
+### Breaking
+
+**The `PROCESS` column and the `process` field in `--json` now report the
+executable, not the thread name.** On Linux this came from `/proc/<pid>/comm`,
+which is the *thread* name — and runtimes overwrite it. A Node dev server
+reported as `MainThread`, exactly as it still does under `ps`, `ss`, and `lsof`.
+macOS and Windows already read the executable; Linux was the odd one out.
+
+Values change accordingly:
+
+| Before | After |
+|--------|-------|
+| `MainThread` | `node` |
+| `python3` | `python3.12` |
+
+`comm` is also truncated to 15 bytes, so previously-clipped names now appear in
+full. If you script against `--json`, check anything that matches on `process`.
+
+`portview ssh <host>` no longer fails when portview is missing on the remote —
+it falls back to agentless collection instead. If you relied on that error,
+note that it is now a warning on stderr.
+
+### Added
+
+- **`portview mcp`** — an MCP server over stdio, so Claude Code, Cursor, and
+  other MCP clients can query and act on ports directly. Five tools;
+  `kill_port` is marked destructive and is withheld entirely under
+  `--read-only`. Adds no dependencies and about 29 KB of binary.
+- **Agentless SSH** — `portview ssh <host>` works without portview installed on
+  the remote, collecting over the same connection with `ss` and `ps`. Automatic,
+  or forced with `--agentless`. Covers scans, port inspection, and process
+  search; `watch` and `doctor` still need portview on the far end.
+- **GitHub Action** — `uses: mapika/portview@v2` runs `doctor` in CI, annotates
+  findings inline, and can fail the job on errors or warnings.
+- `--json` now includes `start_time_unix`, so remote scans report uptime.
+
+### Fixed
+
+- **`doctor`'s stale-connection check could never fire.** Both branches were
+  unreachable for three independent reasons: sockets with no owning process were
+  discarded (which is every `TIME_WAIT` socket), and deduplication collapsed many
+  `CLOSE_WAIT` sockets on one port into a single row, so counts never exceeded 1.
+  Counts now come from the raw socket table. Verified against 60 real
+  `TIME_WAIT` and 16 real `CLOSE_WAIT` sockets.
+- `portview ssh <host>` reported `-` for `UPTIME` whenever the remote had
+  portview installed.
+- Dependabot auto-merge failed on every pull request, because GitHub's
+  auto-merge requires a protected branch.
+
+### Changed
+
+- The README demo recordings are regenerable via `demo/record.sh` and run inside
+  an isolated namespace, so nothing about the machine that produced them leaks.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,12 +45,38 @@ cargo run -- watch --docker
 - Keep platform-specific code in the respective platform module
 - `--json` output must work in all display modes
 
+Only Linux can be run here, but the other two platforms can still be
+type-checked — do this before touching `macos.rs`, `windows.rs`, or anything
+they share:
+
+```bash
+cargo check --target aarch64-apple-darwin
+cargo check --target x86_64-pc-windows-msvc
+```
+
 ## Submitting changes
 
 1. Fork the repo and create a branch from `main`
 2. Make your changes
 3. Ensure `cargo test`, `cargo fmt --check`, and `cargo clippy` pass
 4. Open a pull request
+
+## Releasing
+
+1. Bump the version in `Cargo.toml` and `flake.nix` (they must match), and add a
+   `CHANGELOG.md` entry.
+2. Push a full version tag, e.g. `v2.1.0`. That triggers the release workflow:
+   cross-platform builds, checksums, a GitHub release, and the Homebrew formula
+   update. The tag pattern is `v*.*.*`, so partial tags do not fire it.
+3. Move the major tag so `uses: mapika/portview@v2` keeps resolving:
+
+   ```bash
+   git tag -f v2 && git push -f origin v2
+   ```
+
+   Users pin the GitHub Action to the major tag; without this step that
+   reference breaks. This deliberately does not trigger a release.
+4. `cargo publish` is manual and not run by CI.
 
 ## Reporting bugs
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -973,7 +973,7 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portview"
-version = "1.6.0"
+version = "2.0.0"
 dependencies = [
  "clap",
  "clap_complete",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "portview"
-version = "1.6.0"
+version = "2.0.0"
 edition = "2024"
 description = "A diagnostic-first port viewer. See what's on your ports, then act on it."
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ There's a GitHub Action, so a workflow can fail when a service ends up exposed
 or a test run leaks connections:
 
 ```yaml
-- uses: mapika/portview@v1
+- uses: mapika/portview@v2
   with:
     fail-on: error        # error | warning | never
 ```
@@ -173,7 +173,7 @@ It annotates each finding inline on the run, writes a summary table, and exposes
 `findings` (JSON), `count`, `errors`, and `warnings` as step outputs:
 
 ```yaml
-- uses: mapika/portview@v1
+- uses: mapika/portview@v2
   id: doctor
   with:
     fail-on: never

--- a/flake.nix
+++ b/flake.nix
@@ -15,7 +15,7 @@
         packages = rec {
           portview = pkgs.rustPlatform.buildRustPackage {
             pname = "portview";
-            version = "1.6.0";
+            version = "2.0.0";
 
             src = self;
 


### PR DESCRIPTION
Version bump, changelog, and two release-mechanics fixes.

## Why 2.0 and not 1.7

The `PROCESS` column and the `process` field in `--json` change values. The Linux
collector now reports the executable rather than the thread name:

| Before | After |
|--------|-------|
| `MainThread` | `node` |
| `python3` | `python3.12` |

The old values were wrong — `comm` is the thread name, which Node overwrites, and
it is truncated to 15 bytes. But `--json` is documented for "scripts, dashboards",
so anything matching on `process` will see different strings. That is a
compatibility break regardless of the previous behaviour being a bug.

`portview ssh <host>` also no longer errors when the remote lacks portview; it
falls back to agentless collection.

## Two release-mechanics fixes

**The README documented an action reference that could never work.** It said
`uses: mapika/portview@v1`, but no `v1` tag exists — only `v1.6.0` and friends —
so that would fail to resolve. Now `@v2`, with the major-tag step written into
CONTRIBUTING.md so it actually gets created and moved.

**The release trigger would have fired on the major tag.** It matched `v*`, and
the GitHub Action convention is a moving `v2` tag, so every repoint would have
kicked off a full cross-platform release build and produced a bogus release.
Narrowed to `v*.*.*`.

## Contents

- `Cargo.toml` and `flake.nix` to 2.0.0 (verified in step with each other)
- `CHANGELOG.md`, leading with the breaking change and what to check
- Release procedure in CONTRIBUTING.md, including the major tag and the fact
  that `cargo publish` is manual
- Cross-target type-check instructions for contributors

165 tests, `fmt` and `clippy -D warnings` clean, `portview --version` reports
2.0.0, and the crate package still excludes `demo/`, `action.yml`, and `docs/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
