### PR TITLE
feat: list portview in the official MCP Registry (2.0.1)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -183,12 +183,30 @@ jobs:
             exit 1
           fi
 
-      - name: Tag must match Cargo.toml
+      - name: Tag must match every version we declare
         id: check
         run: |
           set -euo pipefail
           tag="${GITHUB_REF_NAME#v}"
           manifest=$(grep -m1 '^version' Cargo.toml | cut -d'"' -f2)
+
+          # Three files carry the version and all are bumped by hand, so check
+          # them together — flake.nix and server.json are otherwise never
+          # validated and would drift silently.
+          flake=$(grep -m1 'version = "' flake.nix | cut -d'"' -f2)
+          server=$(python3 -c "import json;print(json.load(open('server.json'))['version'])")
+          server_pkg=$(python3 -c "import json;print(json.load(open('server.json'))['packages'][0]['version'])")
+
+          fail=0
+          for pair in "Cargo.toml:$manifest" "flake.nix:$flake" \
+                      "server.json:$server" "server.json packages[0]:$server_pkg"; do
+            file="${pair%%:*}"; value="${pair##*:}"
+            if [ "$value" != "$tag" ]; then
+              echo "::error::${file} says ${value} but the tag is v${tag}"
+              fail=1
+            fi
+          done
+          [ "$fail" -eq 0 ] || exit 1
 
           # Publishing the wrong version is unfixable, so refuse on a mismatch
           # rather than shipping whatever the manifest happened to say.
@@ -218,6 +236,57 @@ jobs:
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
         run: cargo publish
+
+  # Lists portview in the official MCP Registry, which is how MCP clients and
+  # directories discover servers.
+  #
+  # Runs after publish-crate on purpose: the registry verifies ownership by
+  # fetching the crate's README from crates.io and looking for the `mcp-name:`
+  # token, so the version must already be there.
+  publish-mcp:
+    needs: [publish-crate]
+    runs-on: ubuntu-latest
+    permissions:
+      # OIDC proves this repo owns the io.github.mapika/* namespace, so no
+      # long-lived token needs to exist as a secret.
+      id-token: write
+      contents: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Install mcp-publisher
+        run: |
+          set -euo pipefail
+          curl -fsSL "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_linux_amd64.tar.gz" \
+            | tar xz mcp-publisher
+          chmod +x mcp-publisher
+
+      - name: Validate server.json
+        run: ./mcp-publisher validate
+
+      - name: Wait for the crate README to appear on crates.io
+        run: |
+          set -euo pipefail
+          version="${GITHUB_REF_NAME#v}"
+          # Ownership verification reads the rendered README, which lags the
+          # publish by a little. Poll rather than race it.
+          for _ in $(seq 1 20); do
+            if curl -fsSL -H 'User-Agent: portview-release-workflow' \
+                 "https://crates.io/api/v1/crates/portview/${version}" >/dev/null 2>&1; then
+              echo "crates.io has ${version}"
+              sleep 15
+              exit 0
+            fi
+            sleep 15
+          done
+          echo "::error::portview ${version} did not appear on crates.io in time"
+          exit 1
+
+      - name: Authenticate to the MCP Registry
+        run: ./mcp-publisher login github-oidc
+
+      - name: Publish to the MCP Registry
+        run: ./mcp-publisher publish
 
   update-homebrew:
     needs: [release]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 2.0.1
+
+No functional changes. This release exists so portview can be listed in the
+[MCP Registry](https://registry.modelcontextprotocol.io), which verifies
+ownership by looking for an `mcp-name:` token in the crate's README on
+crates.io — and 2.0.0's README predates it. crates.io versions are immutable,
+so the token cannot be added retroactively.
+
+- Listed in the official MCP Registry as `io.github.mapika/portview`
+- Release workflow now publishes to the MCP Registry, and checks the tag against
+  `Cargo.toml`, `flake.nix`, and `server.json` together
+
 ## 2.0.0
 
 ### Breaking

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,8 +63,11 @@ cargo check --target x86_64-pc-windows-msvc
 
 ## Releasing
 
-1. Bump the version in `Cargo.toml` and `flake.nix` (they must match), and add a
-   `CHANGELOG.md` entry.
+1. Bump the version in `Cargo.toml`, `flake.nix`, and `server.json` (both the
+   top-level `version` and `packages[0].version`), and add a `CHANGELOG.md`
+   entry. The release workflow checks all of them against the tag and fails on
+   any mismatch, so a missed file turns into a red release rather than a wrong
+   publish.
 2. Push a full version tag, e.g. `v2.1.0`. That triggers the release workflow:
    cross-platform builds, checksums, a GitHub release, and the Homebrew formula
    update. The tag pattern is `v*.*.*`, so partial tags do not fire it.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -973,7 +973,7 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portview"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "clap",
  "clap_complete",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "portview"
-version = "2.0.0"
+version = "2.0.1"
 edition = "2024"
 description = "A diagnostic-first port viewer. See what's on your ports, then act on it."
 license = "MIT"
 repository = "https://github.com/mapika/portview"
 keywords = ["port", "process", "diagnostic", "network", "cli"]
 categories = ["command-line-utilities"]
-exclude = ["*.mp4", "aur/", ".github/", "demo/", "action.yml"]
+exclude = ["*.mp4", "aur/", ".github/", "demo/", "action.yml", "server.json"]
 
 [dependencies]
 clap = { version = "4", features = ["derive"] }

--- a/README.md
+++ b/README.md
@@ -111,6 +111,9 @@ Pass `--read-only` to withhold `kill_port` entirely, so the agent can look but n
 portview mcp --read-only
 ```
 
+Listed in the [MCP Registry](https://registry.modelcontextprotocol.io) as
+`mcp-name: io.github.mapika/portview`.
+
 ### Watch mode (interactive TUI)
 
 ```bash

--- a/flake.nix
+++ b/flake.nix
@@ -15,7 +15,7 @@
         packages = rec {
           portview = pkgs.rustPlatform.buildRustPackage {
             pname = "portview";
-            version = "2.0.0";
+            version = "2.0.1";
 
             src = self;
 

--- a/server.json
+++ b/server.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.mapika/portview",
+  "title": "portview",
+  "description": "See what's on your ports, the processes behind them, and diagnose conflicts and leaks.",
+  "repository": {
+    "url": "https://github.com/Mapika/portview",
+    "source": "github"
+  },
+  "websiteUrl": "https://github.com/Mapika/portview",
+  "version": "2.0.1",
+  "packages": [
+    {
+      "registryType": "cargo",
+      "identifier": "portview",
+      "version": "2.0.1",
+      "transport": {
+        "type": "stdio"
+      },
+      "packageArguments": [
+        {
+          "type": "positional",
+          "value": "mcp",
+          "valueHint": "subcommand"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
portview has shipped an MCP server since 2.0.0 and isn't listed in any registry, so the audience it was built for can't find it. This adds the listing and automates it.

## What's here

- `server.json`, validated against the live registry with `mcp-publisher validate`
- A `publish-mcp` job in the release workflow, authenticating via **GitHub OIDC** — no long-lived token as a secret
- Version bump to 2.0.1

## Two things that would have failed silently

**The ownership token has to be visible.** The registry verifies Cargo ownership by fetching the crate README from crates.io and looking for an `mcp-name:` token. Unlike PyPI and NuGet, **crates.io strips HTML comments** during markdown rendering, so the usual hidden `<!-- mcp-name: ... -->` form is invisible to the validator. It's therefore visible markdown in the README's MCP section.

**The registry declares the binary, not the subcommand.** portview's server is `portview mcp`, so `packageArguments` pins the positional `mcp`. Without it a client would run bare `portview` and get a rendered table instead of JSON-RPC.

## Why 2.0.1 is needed

crates.io versions are immutable, so the `mcp-name:` token can't be added to 2.0.0 retroactively. 2.0.1 has no functional changes — it exists to carry the README token so verification can pass.

## Also

Extends the release version guard to check `flake.nix` and `server.json`, not just `Cargo.toml`. All three are bumped by hand and `flake.nix` was never validated, so it could have drifted silently. Verified in both directions: a matching tag passes, a mismatch fails and names each offending file.

`publish-mcp` runs after `publish-crate` and polls crates.io, since ownership verification reads a README that doesn't exist until the crate is up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
