### PR TITLE
fix: correct MCP Registry namespace casing (2.0.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 2.0.2
+
+No functional changes. Corrects the MCP Registry namespace, which is
+case-sensitive and follows the GitHub account's own casing:
+`io.github.Mapika/portview`, not `io.github.mapika/portview`. The registry
+rejected 2.0.1 with a 403 on that mismatch.
+
+Because the ownership token lives in the crate README on crates.io and published
+versions are immutable, the corrected token needs a new version to travel on.
+
 ## 2.0.1
 
 No functional changes. This release exists so portview can be listed in the

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -973,7 +973,7 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portview"
-version = "2.0.1"
+version = "2.0.2"
 dependencies = [
  "clap",
  "clap_complete",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "portview"
-version = "2.0.1"
+version = "2.0.2"
 edition = "2024"
 description = "A diagnostic-first port viewer. See what's on your ports, then act on it."
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ portview mcp --read-only
 ```
 
 Listed in the [MCP Registry](https://registry.modelcontextprotocol.io) as
-`mcp-name: io.github.mapika/portview`.
+`mcp-name: io.github.Mapika/portview`.
 
 ### Watch mode (interactive TUI)
 

--- a/flake.nix
+++ b/flake.nix
@@ -15,7 +15,7 @@
         packages = rec {
           portview = pkgs.rustPlatform.buildRustPackage {
             pname = "portview";
-            version = "2.0.1";
+            version = "2.0.2";
 
             src = self;
 

--- a/server.json
+++ b/server.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
-  "name": "io.github.mapika/portview",
+  "name": "io.github.Mapika/portview",
   "title": "portview",
   "description": "See what's on your ports, the processes behind them, and diagnose conflicts and leaks.",
   "repository": {
@@ -8,12 +8,12 @@
     "source": "github"
   },
   "websiteUrl": "https://github.com/Mapika/portview",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "packages": [
     {
       "registryType": "cargo",
       "identifier": "portview",
-      "version": "2.0.1",
+      "version": "2.0.2",
       "transport": {
         "type": "stdio"
       },


### PR DESCRIPTION
The 2.0.1 release published everywhere except the MCP Registry, which rejected it:

```
403 Forbidden: You do not have permission to publish this server.
You have permission to publish: io.github.Mapika/*.
Attempting to publish: io.github.mapika/portview.
```

The namespace follows the GitHub account's own casing and the comparison is case-sensitive. I assumed lowercase. `server.json` and the README ownership token both said `io.github.mapika`.

## Why this needs 2.0.2 rather than a re-tag

The ownership token is verified against the crate README **as served by crates.io**, and published versions are immutable. 2.0.1's README carries the lowercase token permanently — confirmed by fetching the rendered README from crates.io. So the corrected token has to ride on a version that hasn't shipped.

I considered re-pointing the v2.0.1 tag and letting `publish-crate` skip, but the registry's namespace check is demonstrably case-sensitive, so the token check probably is too — and that would have been a third move of a public tag on a gamble.

No functional changes. 2.0.1 remains fine on crates.io, Homebrew, and GitHub releases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
