### PR TITLE
feat: add a Dockerfile; fix musl time_t deprecation warning

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,9 @@
+# Keep the build context small and the image reproducible.
+target/
+.git/
+.github/
+demo/
+docs/
+aur/
+.playwright-mcp/
+*.mp4

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,44 @@
+# portview as a container image.
+#
+# Read this before using it: a container gets its own network and PID
+# namespaces, so portview running inside one sees *the container's* ports and
+# processes — which is to say, almost nothing. That is not a bug in portview;
+# it is what namespaces are for. The demo recordings in demo/ rely on exactly
+# this behaviour to isolate themselves.
+#
+# To inspect the host, share its namespaces:
+#
+#   docker run --rm -i --network host --pid host portview
+#
+# Without --network host the port list is empty. Without --pid host the ports
+# resolve but the processes behind them do not.
+#
+# For everyday use, install the binary instead — it is ~1 MB with no runtime
+# dependencies:
+#
+#   cargo install portview
+#   brew install mapika/tap/portview
+
+FROM rust:alpine AS builder
+
+# The libc crate needs a C toolchain against musl.
+RUN apk add --no-cache musl-dev
+
+WORKDIR /src
+COPY . .
+
+# --locked so the image matches the committed Cargo.lock rather than resolving
+# fresh dependencies at build time.
+RUN cargo build --release --locked
+
+FROM alpine:3
+
+# procps is not required: portview reads /proc directly rather than shelling
+# out to ps, ss, or lsof.
+COPY --from=builder /src/target/release/portview /usr/local/bin/portview
+
+# Defaults to the MCP server, which is the usual reason to run this in a
+# container. Override for the CLI:
+#
+#   docker run --rm --network host --pid host --entrypoint portview <image> doctor
+ENTRYPOINT ["portview", "mcp"]

--- a/README.md
+++ b/README.md
@@ -310,6 +310,14 @@ cargo build --release
 
 Requires Rust 1.85+ (edition 2024). Shell completions and man page are generated at build time.
 
+There's also a `Dockerfile`. Note that a container has its own network and PID
+namespaces, so portview inside one sees the *container's* ports — share the
+host's namespaces to inspect the host:
+
+```bash
+docker run --rm -i --network host --pid host portview
+```
+
 ## Contributing
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for development setup and guidelines, and

--- a/src/main.rs
+++ b/src/main.rs
@@ -1172,7 +1172,11 @@ pub(crate) fn chrono_free_time() -> String {
     // Read local timezone offset from libc
     let offset_secs: i64 = unsafe {
         let mut tm: libc::tm = std::mem::zeroed();
-        let time = secs_since_epoch as libc::time_t;
+        // The type is inferred from localtime_r's signature rather than written
+        // as libc::time_t, which is deprecated on musl: the alias is due to
+        // widen to 64-bit there, and naming it warns on every musl release
+        // build. Inference stays correct whichever width it ends up being.
+        let time = secs_since_epoch as _;
         libc::localtime_r(&time, &mut tm);
         tm.tm_gmtoff
     };


### PR DESCRIPTION
The Glama listing check — a prerequisite for the [awesome-mcp-servers PR](https://github.com/punkpeye/awesome-mcp-servers/pull/11265) — introspects the server from a container image, so portview needs one.

## The Dockerfile leads with a caveat

A container has its own network and PID namespaces, so portview inside one sees **the container's** ports — almost nothing. `--network host --pid host` is required to inspect the host. An image that silently reports an empty port list would be worse than no image, so that's stated in the Dockerfile header, the entrypoint comment, and the README.

(This is the same mechanism `demo/record.sh` relies on to isolate recordings.)

## A real warning it surfaced

Building against musl for the alpine image exposed a warning already present in the two musl targets the release workflow ships:

```
warning: use of deprecated type alias `libc::time_t`: This type is changed to
64-bit in musl 1.2.0, we'll follow that change in the future release.
```

`chrono_free_time` named `libc::time_t` to cast epoch seconds for `localtime_r`. The type is now inferred from `localtime_r`'s signature instead — correct whichever width musl settles on, and the warning is gone.

## What is and isn't verified

**Verified:** `cargo build --release --locked` against both glibc and musl (zero warnings now, was one); macOS and Windows still type-check; 165 tests pass; and the check Glama actually performs — `portview mcp` starts and answers `initialize` and `tools/list`.

**Not verified:** the container build itself. No Docker daemon was available in this environment. The musl compile was checked natively, which is the part most likely to break.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
EOF