### PR TITLE
fix: stop hiding ports whose owner cannot be resolved

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,29 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+
+**Ports whose owner could not be resolved were hidden entirely.** This is the
+worst failure mode for a port viewer: it reported a port as free when something
+was listening on it. On a normal Linux user account, `ss -tlnH` showed a
+root-owned listener on `:53` while `portview` reported no TCP listeners at all.
+
+Such sockets are now listed with `-` in the columns that cannot be filled, on
+Linux and Windows. Two causes, previously indistinguishable because both were
+silently dropped: the socket belongs to another user and `/proc/<pid>/fd` is
+unreadable without `sudo`, or nothing owns it at all (`TIME_WAIT` outlives the
+process that opened it).
+
+macOS is unchanged here — it enumerates sockets per process, so a process that
+cannot be opened contributes nothing to enumerate in the first place.
+
+**`--all` collapsed connections, contradicting `doctor`.** Non-listening rows
+were deduplicated by `(port, protocol, pid)`, so sixty `TIME_WAIT` sockets on
+one port rendered as a single row. `doctor` would report a connection leak that
+`--all` then appeared to disprove. Connections are now one row each; listeners
+are still deduplicated, since a process bound to both v4 and v6 is one listener.
+
 ## 2.0.2
 
 No functional changes. Corrects the MCP Registry namespace, which is

--- a/README.md
+++ b/README.md
@@ -66,7 +66,9 @@ $ portview
 ╰──────┴───────┴─────┴──────────────┴──────┴────────────┴────────┴────────┴────────────────────────────╯
 ```
 
-`--all` includes non-listening connections. `--wide` shows full commands. `--json` for scripting.
+`--all` includes non-listening connections — one row per connection, so a pile-up of `TIME_WAIT` or `CLOSE_WAIT` sockets is visible rather than collapsed. `--wide` shows full commands. `--json` for scripting.
+
+Ports whose owner can't be resolved are still listed, with `-` in the columns that can't be filled. That happens for another user's process without `sudo`, and for sockets like `TIME_WAIT` that outlive the process that opened them.
 
 > The scan, doctor, and MCP examples below are real output, captured by [`demo/record.sh`](demo/README.md) inside an isolated namespace — which is why the user is `root` and the paths are `/opt/app`. The Docker example is illustrative, since it needs a running daemon.
 
@@ -332,9 +334,9 @@ cargo check --target x86_64-pc-windows-msvc
 
 ## Limitations
 
-- **Linux:** Other users' processes require `sudo` (needs `/proc/<pid>/fd/` access)
-- **macOS:** Other users' processes may require `sudo`. Doctor cannot detect TIME_WAIT pileups: sockets are enumerated per process via `proc_pidfdinfo`, and a TIME_WAIT socket outlives the process that owned it. CLOSE_WAIT is detected normally.
-- **Windows:** Some system processes not accessible. Kill always force-terminates. Run as Administrator for full visibility.
+- **Linux:** Other users' ports are listed, but naming the process needs `sudo` (it reads `/proc/<pid>/fd/`). Rows you can't attribute show `-` for PID, user, process, and command rather than being hidden.
+- **macOS:** Other users' ports are *not* listed without `sudo` — sockets are enumerated per process via `proc_pidfdinfo`, so a process that can't be opened contributes nothing to enumerate. For the same reason doctor cannot detect TIME_WAIT pileups there; CLOSE_WAIT is detected normally.
+- **Windows:** Ports owned by inaccessible system processes are listed with the PID but `-` for name and user. Kill always force-terminates. Run as Administrator for full detail.
 - **Docker:** Requires `docker` CLI and daemon access
 - **SSH:** `watch` and `doctor` require portview on the remote host. Scans fall back to agentless collection (`ss` + `ps`), which needs a Linux remote — macOS and BSD hosts still need portview installed.
 

--- a/src/linux.rs
+++ b/src/linux.rs
@@ -343,9 +343,39 @@ pub fn get_port_infos(filter_listening: bool) -> Vec<PortInfo> {
             continue;
         }
 
+        // No resolvable owner. Two causes, indistinguishable to the caller and
+        // both previously hidden: the socket has no owning process at all
+        // (TIME_WAIT outlives it, inode 0), or it belongs to another user and
+        // we are not root, so /proc/<pid>/fd was unreadable.
+        //
+        // These are listed with placeholders rather than dropped. Hiding them
+        // made portview under-report: a root-owned listener on :53 simply did
+        // not appear for a non-root user, who would reasonably conclude the
+        // port was free.
         let pid = match inode_map.get(&sock.inode) {
             Some(&p) => p,
-            None => continue,
+            None => {
+                infos.push(PortInfo {
+                    port: sock.local_port,
+                    protocol: sock
+                        .protocol
+                        .strip_suffix('6')
+                        .unwrap_or(&sock.protocol)
+                        .to_string(),
+                    pid: 0,
+                    ppid: 0,
+                    process_name: String::new(),
+                    command: String::new(),
+                    user: String::new(),
+                    state: sock.state,
+                    memory_bytes: 0,
+                    cpu_seconds: 0.0,
+                    start_time: None,
+                    children: 0,
+                    local_addr: sock.local_addr,
+                });
+                continue;
+            }
         };
 
         let (uid, ppid, rss_bytes) = parse_proc_status(pid);
@@ -372,9 +402,6 @@ pub fn get_port_infos(filter_listening: bool) -> Vec<PortInfo> {
         });
     }
 
-    // Drop entries where we couldn't read process details (other user's process without sudo)
-    infos.retain(|i| !i.process_name.is_empty());
-
     // Sort by port number, then protocol, then pid (pid needed for dedup_by adjacency)
     infos.sort_by(|a, b| {
         a.port
@@ -383,8 +410,27 @@ pub fn get_port_infos(filter_listening: bool) -> Vec<PortInfo> {
             .then_with(|| a.pid.cmp(&b.pid))
     });
 
-    // Deduplicate (same port+proto+pid can appear for v4 and v6)
-    infos.dedup_by(|a, b| a.port == b.port && a.protocol == b.protocol && a.pid == b.pid);
+    // Deduplicate listeners only: one process listening on both v4 and v6 is a
+    // single logical listener and should appear once.
+    //
+    // Connections are NOT deduplicated. Each established or TIME_WAIT socket is
+    // a distinct connection, and collapsing them by (port, protocol, pid) is
+    // what made `--all` report a single row where the kernel had sixty — and
+    // what made doctor's leak findings impossible to corroborate on screen.
+    let (mut listeners, connections): (Vec<PortInfo>, Vec<PortInfo>) = infos
+        .into_iter()
+        .partition(|i| i.state == TcpState::Listen || i.protocol.starts_with("UDP"));
+
+    listeners.dedup_by(|a, b| a.port == b.port && a.protocol == b.protocol && a.pid == b.pid);
+
+    let mut infos = listeners;
+    infos.extend(connections);
+    infos.sort_by(|a, b| {
+        a.port
+            .cmp(&b.port)
+            .then_with(|| a.protocol.cmp(&b.protocol))
+            .then_with(|| a.pid.cmp(&b.pid))
+    });
 
     infos
 }

--- a/src/macos.rs
+++ b/src/macos.rs
@@ -578,7 +578,14 @@ pub fn get_port_infos(filter_listening: bool) -> Vec<PortInfo> {
     }
 
     // Drop entries where we couldn't read process details (other user's process without sudo)
-    infos.retain(|i| !i.process_name.is_empty());
+    // Kept rather than dropped: if we enumerated a socket but could not name
+    // its process, the port is still real and hiding it under-reports. Unnamed
+    // fields render as "-".
+    //
+    // Note this cannot recover another user's ports on macOS the way it does on
+    // Linux and Windows: sockets are enumerated per-process via proc_pidfdinfo,
+    // so a process we cannot open contributes no sockets to enumerate in the
+    // first place. There is no socket table to diff against.
 
     // Sort by port number, then protocol, then pid (pid needed for dedup_by adjacency)
     infos.sort_by(|a, b| {

--- a/src/main.rs
+++ b/src/main.rs
@@ -56,6 +56,38 @@ pub(crate) struct PortInfo {
     pub(crate) local_addr: IpAddr,
 }
 
+/// What is behind a row.
+///
+/// `pid == 0` alone is ambiguous: it marks both synthesised Docker rows and
+/// sockets whose owner we could not resolve. They render differently, so the
+/// distinction is made once here rather than re-derived at each call site.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum OwnerKind {
+    /// A real process we could read.
+    Process,
+    /// A container-published port with no host process.
+    Container,
+    /// A socket with no resolvable owner: either nothing owns it (TIME_WAIT
+    /// outlives its process) or it belongs to another user and we are not root.
+    /// Listed with placeholders rather than hidden — a port viewer that omits
+    /// ports is worse than one that admits it cannot name the owner.
+    Unowned,
+}
+
+impl PortInfo {
+    pub(crate) fn owner_kind(&self) -> OwnerKind {
+        if self.pid != 0 {
+            OwnerKind::Process
+        } else if self.user == "docker" {
+            // The only producer of pid-0 rows with a user is
+            // `synthesize_docker_entries`, which always sets exactly this.
+            OwnerKind::Container
+        } else {
+            OwnerKind::Unowned
+        }
+    }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub(crate) enum TcpState {
     Listen,
@@ -637,21 +669,32 @@ fn display_table(
         } else {
             info.pid.to_string()
         };
+        // A socket whose owner we could not resolve still gets a row; blank
+        // cells would read as a rendering fault, so unknown fields show "-"
+        // exactly like the numeric columns already do.
+        let dash_if_empty = |s: &str| {
+            if s.is_empty() {
+                "-".to_string()
+            } else {
+                s.to_string()
+            }
+        };
         let base_values = [
             info.port.to_string(),
             info.protocol.clone(),
             pid_str,
             info.local_addr.to_string(),
-            info.user.clone(),
-            info.process_name.clone(),
+            dash_if_empty(&info.user),
+            dash_if_empty(&info.process_name),
             uptime_str,
             mem_str,
         ];
 
+        let command = dash_if_empty(&info.command);
         let cmd_lines = if wide {
-            wrap_cmd(&info.command, actual_cmd_w)
+            wrap_cmd(&command, actual_cmd_w)
         } else {
-            vec![info.command.clone()]
+            vec![command]
         };
 
         for (line_idx, cmd_line) in cmd_lines.iter().enumerate() {
@@ -718,7 +761,7 @@ fn display_detail(info: &PortInfo, use_color: bool) {
     let mut out = io::stdout();
     let bind_str = format!("{}:{}", format_addr(&info.local_addr), info.port);
     let uptime = format_uptime(info.start_time);
-    let is_docker = info.pid == 0;
+    let is_docker = info.owner_kind() == OwnerKind::Container;
 
     let _ = writeln!(out);
     if use_color {
@@ -1847,6 +1890,61 @@ mod tests {
     }
 
     // ── wrap_cmd ───────────────────────────────────────────────────
+
+    fn port_fixture(port: u16, pid: u32, name: &str) -> PortInfo {
+        PortInfo {
+            port,
+            protocol: "TCP".to_string(),
+            pid,
+            ppid: 1,
+            process_name: name.to_string(),
+            command: "cmd".to_string(),
+            user: "mark".to_string(),
+            state: TcpState::Listen,
+            memory_bytes: 1024,
+            cpu_seconds: 0.0,
+            start_time: None,
+            children: 0,
+            local_addr: IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)),
+        }
+    }
+
+    #[test]
+    fn owner_kind_distinguishes_container_from_unowned() {
+        // pid == 0 alone is ambiguous: it marks both synthesised Docker rows
+        // and sockets with no resolvable owner. They render differently.
+        let mut p = port_fixture(8080, 42, "app");
+        assert_eq!(p.owner_kind(), OwnerKind::Process);
+
+        p.pid = 0;
+        p.user = "docker".to_string();
+        p.process_name = "pv-nginx".to_string();
+        assert_eq!(p.owner_kind(), OwnerKind::Container);
+
+        // No owner: TIME_WAIT, or another user's process without root.
+        p.user = String::new();
+        p.process_name = String::new();
+        assert_eq!(p.owner_kind(), OwnerKind::Unowned);
+    }
+
+    #[test]
+    fn unowned_rows_serialise_with_null_start_time_and_zero_pid() {
+        // These rows exist so ports are not hidden; the JSON has to survive
+        // them too, since MCP and remote scans both parse it.
+        let mut p = port_fixture(53, 0, "");
+        p.user = String::new();
+        p.command = String::new();
+        p.start_time = None;
+
+        let json = port_info_json(&p, None);
+        assert!(json.contains(r#""pid":0"#), "{}", json);
+        assert!(json.contains(r#""start_time_unix":null"#), "{}", json);
+        // Must round-trip: remote scans parse exactly this.
+        let parsed = crate::ssh::parse_port_json(&format!("[{}]", json)).unwrap();
+        assert_eq!(parsed[0].port, 53);
+        assert_eq!(parsed[0].pid, 0);
+        assert_eq!(parsed[0].owner_kind(), OwnerKind::Unowned);
+    }
 
     #[test]
     fn wrap_cmd_empty() {

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -559,8 +559,12 @@ pub fn get_port_infos(filter_listening: bool) -> Vec<PortInfo> {
         }
     }
 
-    // Drop entries where we couldn't read process details (other user's process without elevated privileges)
-    infos.retain(|i| !i.process_name.is_empty());
+    // Entries whose process details could not be read are kept rather than
+    // dropped. GetExtendedTcpTable still gave us the owning PID, so the row is
+    // useful even unnamed — and hiding it made portview under-report, which for
+    // a port viewer is the worst failure mode: a system-owned listener simply
+    // vanished for an unelevated user, who would read that as a free port.
+    // Unnamed fields render as "-".
 
     // Sort by port number, then protocol, then pid (pid needed for dedup_by adjacency)
     infos.sort_by(|a, b| {
@@ -570,8 +574,24 @@ pub fn get_port_infos(filter_listening: bool) -> Vec<PortInfo> {
             .then_with(|| a.pid.cmp(&b.pid))
     });
 
-    // Deduplicate (same port+proto+pid can appear for v4 and v6)
-    infos.dedup_by(|a, b| a.port == b.port && a.protocol == b.protocol && a.pid == b.pid);
+    // Deduplicate listeners only: one process listening on both v4 and v6 is a
+    // single logical listener. Connections stay distinct — each established or
+    // TIME_WAIT socket is its own connection, and collapsing them by
+    // (port, protocol, pid) hid genuine connection pile-ups.
+    let (mut listeners, connections): (Vec<PortInfo>, Vec<PortInfo>) = infos
+        .into_iter()
+        .partition(|i| i.state == TcpState::Listen || i.protocol.starts_with("UDP"));
+
+    listeners.dedup_by(|a, b| a.port == b.port && a.protocol == b.protocol && a.pid == b.pid);
+
+    let mut infos = listeners;
+    infos.extend(connections);
+    infos.sort_by(|a, b| {
+        a.port
+            .cmp(&b.port)
+            .then_with(|| a.protocol.cmp(&b.protocol))
+            .then_with(|| a.pid.cmp(&b.pid))
+    });
 
     infos
 }


### PR DESCRIPTION
A port viewer that omits ports is failing at its one job. On an ordinary Linux user account, before this change:

```
$ ss -tlnH
LISTEN 0 1000 10.255.255.254:53 ...

$ portview
(no TCP listeners)
```

The root-owned listener on `:53` wasn't shown as *owner unknown* — it was **absent entirely**, and a user would reasonably read that as a free port. I found this while investigating the `doctor`/`--all` disagreement; it turned out to be the same root cause and considerably more serious.

## Cause

Every platform ended collection with:

```rust
infos.retain(|i| !i.process_name.is_empty());
```

which dropped any socket whose owning process couldn't be read. Two distinct causes both landed there:

1. the process belongs to another user and `/proc/<pid>/fd` needs root
2. nothing owns the socket at all — `TIME_WAIT` outlives the process that opened it

## Fix

Those rows are listed with `-` in the columns that can't be filled.

- **Windows** keeps the PID, which `GetExtendedTcpTable` supplies even when the process can't be opened — so those rows are more informative than Linux's.
- **macOS** is unchanged in effect and now says so honestly in Limitations: it enumerates sockets per process via `proc_pidfdinfo`, so a process that can't be opened contributes nothing to enumerate. There's no socket table to diff against.

## Also: `--all` no longer collapses connections

Non-listening rows were deduplicated by `(port, protocol, pid)`, so sixty `TIME_WAIT` sockets on one port rendered as a single row — `doctor` would report a connection leak that `--all` then appeared to disprove.

Verified against the kernel:

| | before | after |
|---|---|---|
| kernel `TIME_WAIT` on :7300 | 60 | 60 |
| `doctor` | reports 60 | reports 60 |
| `portview --all` rows | **1** | **61** (60 + listener) |
| default view rows | 1 | 1 (unchanged) |

Listeners are still deduplicated — one process bound to v4 and v6 is one listener.

## Incidental

`pid == 0` meant *"this is a Docker row"* at every call site, which collides with these unowned rows. That's now an explicit `OwnerKind` derived in one place.

## Verification

167 tests (2 new, covering the owner distinction and that unowned rows survive the JSON round-trip that MCP and remote scans depend on), `fmt` and `clippy -D warnings` clean, macOS and Windows type-check.

**Note for release:** this makes previously-hidden ports visible, so anything counting rows from `--json` will see more. I'd call that a minor bump rather than a patch. Changelog entry is under `## Unreleased`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)