### PR TITLE
feat(ssh): diagnose remote hosts with nothing installed on them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## Unreleased
 
+### Added
+
+- `portview ssh <host> doctor --agentless` diagnoses a remote host with nothing
+  installed on it. The checks are pure functions over collected data, so the
+  same code runs against remote evidence rather than a second implementation
+  that drifts. Verified to produce output identical to running `portview doctor`
+  on the host itself. The Docker check reports as skipped, since the probe does
+  not query Docker on the far end.
+
 ### Fixed
 
 **Ports whose owner could not be resolved were hidden entirely.** This is the

--- a/README.md
+++ b/README.md
@@ -221,9 +221,20 @@ the process, user, memory, uptime, and full command — it resolves
 `/proc/<pid>/exe` on the remote host, so a Node server reads as `node` rather
 than the `MainThread` that `ss` reports.
 
-Agentless mode covers scans, port inspection, and process search. `watch` and
-`doctor` still need portview installed remotely — the TUI consumes a streaming
-JSON pipe, and doctor's checks run on the far end.
+`doctor` works agentless too — the checks are pure functions over collected
+data, so they run locally against whatever the probe brought back:
+
+```bash
+portview ssh user@server doctor --agentless
+```
+
+That produces the same findings as running `portview doctor` on the host
+itself. The Docker check is reported as skipped rather than passed, since the
+probe doesn't query Docker on the far end.
+
+Agentless mode covers scans, port inspection, process search, and diagnostics.
+`watch` still needs portview installed remotely — the TUI consumes a streaming
+JSON pipe.
 
 ### Docker integration
 
@@ -338,7 +349,7 @@ cargo check --target x86_64-pc-windows-msvc
 - **macOS:** Other users' ports are *not* listed without `sudo` — sockets are enumerated per process via `proc_pidfdinfo`, so a process that can't be opened contributes nothing to enumerate. For the same reason doctor cannot detect TIME_WAIT pileups there; CLOSE_WAIT is detected normally.
 - **Windows:** Ports owned by inaccessible system processes are listed with the PID but `-` for name and user. Kill always force-terminates. Run as Administrator for full detail.
 - **Docker:** Requires `docker` CLI and daemon access
-- **SSH:** `watch` and `doctor` require portview on the remote host. Scans fall back to agentless collection (`ss` + `ps`), which needs a Linux remote — macOS and BSD hosts still need portview installed.
+- **SSH:** `watch` requires portview on the remote host. Scans, inspection, search and `doctor` fall back to agentless collection (`ss` + `ps`), which needs a Linux remote — macOS and BSD hosts still need portview installed.
 
 ## License
 

--- a/src/agentless.rs
+++ b/src/agentless.rs
@@ -124,12 +124,16 @@ pub(crate) fn parse_probe(output: &str) -> Result<Vec<PortInfo>, String> {
         }
     }
 
-    // Match the local pipeline: one row per (port, protocol, pid).
+    // Match the local pipeline: deduplicate listeners only.
     //
-    // LISTEN sorts first within a group so that dedup keeps it. A process
-    // usually has both a listening socket and established connections on the
-    // same port; if an ESTAB row won, the port would disappear from the default
-    // listening-only view entirely.
+    // Connections are kept distinct. Collapsing them by (port, protocol, pid)
+    // would hide a pile-up of TIME_WAIT or CLOSE_WAIT sockets behind a single
+    // row — and remote doctor counts those rows to find connection leaks, so
+    // deduplicating here would make the leak undetectable over SSH.
+    //
+    // LISTEN sorts first within a group so dedup keeps it: a process usually has
+    // both a listening socket and connections on the same port, and if an ESTAB
+    // row won, the port would vanish from the default listening-only view.
     let listen_first = |p: &PortInfo| u8::from(p.state != TcpState::Listen);
     infos.sort_by(|a, b| {
         a.port
@@ -138,9 +142,32 @@ pub(crate) fn parse_probe(output: &str) -> Result<Vec<PortInfo>, String> {
             .then_with(|| a.pid.cmp(&b.pid))
             .then_with(|| listen_first(a).cmp(&listen_first(b)))
     });
-    infos.dedup_by(|a, b| a.port == b.port && a.protocol == b.protocol && a.pid == b.pid);
+
+    let (mut listeners, connections): (Vec<PortInfo>, Vec<PortInfo>) = infos
+        .into_iter()
+        .partition(|i| i.state == TcpState::Listen || i.protocol.starts_with("UDP"));
+    listeners.dedup_by(|a, b| a.port == b.port && a.protocol == b.protocol && a.pid == b.pid);
+
+    let mut infos = listeners;
+    infos.extend(connections);
+    infos.sort_by(|a, b| a.port.cmp(&b.port).then_with(|| a.pid.cmp(&b.pid)));
 
     Ok(infos)
+}
+
+/// Count TIME_WAIT / CLOSE_WAIT sockets per port from collected remote rows.
+///
+/// The local collectors read these from the raw socket table; over SSH the
+/// probe's rows are the raw table, so counting them directly is equivalent —
+/// but only because connections above are left un-deduplicated.
+pub(crate) fn stale_counts(infos: &[PortInfo]) -> HashMap<(u16, TcpState), u32> {
+    let mut counts = HashMap::new();
+    for i in infos {
+        if matches!(i.state, TcpState::TimeWait | TcpState::CloseWait) {
+            *counts.entry((i.port, i.state)).or_insert(0) += 1;
+        }
+    }
+    counts
 }
 
 /// Keep only listening sockets, mirroring `get_port_infos(filter_listening)`.
@@ -488,10 +515,11 @@ UNCONN 0      0      0.0.0.0:68          0.0.0.0:*    users:((\"dhclient\",pid=5
     }
 
     #[test]
-    fn dedup_keeps_the_listening_row() {
-        // pid 6 has both LISTEN and ESTAB on 3000. They collapse to one row, and
-        // it must be the listener — otherwise the port vanishes from the default
-        // view. Feed ESTAB first to prove order does not decide it.
+    fn listeners_dedup_but_connections_survive() {
+        // pid 6 has both LISTEN and ESTAB on 3000. The listener must appear
+        // exactly once, and the connection must not be folded into it —
+        // collapsing connections is what hid leak pile-ups from remote doctor.
+        // Feed ESTAB first to prove input order does not decide which survives.
         let reordered = SAMPLE.replace(
             "LISTEN 0      511    127.0.0.1:3000      0.0.0.0:*    users:((\"MainThread\",pid=6,fd=21))\nESTAB  0      0      127.0.0.1:3000      127.0.0.1:51234 users:((\"MainThread\",pid=6,fd=24))",
             "ESTAB  0      0      127.0.0.1:3000      127.0.0.1:51234 users:((\"MainThread\",pid=6,fd=24))\nLISTEN 0      511    127.0.0.1:3000      0.0.0.0:*    users:((\"MainThread\",pid=6,fd=21))",
@@ -501,9 +529,38 @@ UNCONN 0      0      0.0.0.0:68          0.0.0.0:*    users:((\"dhclient\",pid=5
         for input in [SAMPLE, reordered.as_str()] {
             let ports = parse_probe(input).unwrap();
             let rows: Vec<_> = ports.iter().filter(|p| p.port == 3000).collect();
-            assert_eq!(rows.len(), 1);
-            assert_eq!(rows[0].state, TcpState::Listen);
+            assert_eq!(
+                rows.iter().filter(|p| p.state == TcpState::Listen).count(),
+                1,
+                "listener should appear exactly once"
+            );
+            assert_eq!(
+                rows.iter()
+                    .filter(|p| p.state == TcpState::Established)
+                    .count(),
+                1,
+                "connection must not be collapsed into the listener"
+            );
         }
+    }
+
+    #[test]
+    fn stale_counts_survive_collection() {
+        // Remote doctor counts these rows to find leaks, so a pile-up on one
+        // port has to reach it intact rather than deduplicated to one.
+        let mut input = String::from("#TCP\n");
+        for i in 0..14 {
+            input.push_str(&format!(
+                "CLOSE-WAIT 0 0 127.0.0.1:7000 127.0.0.1:{} users:((\"srv\",pid=5,fd={}))\n",
+                40000 + i,
+                i
+            ));
+        }
+        input.push_str("#UDP\n#PROC\n    5     1 root 1000 60 0 srv\n#EXE\n#END\n");
+
+        let ports = parse_probe(&input).unwrap();
+        let counts = stale_counts(&ports);
+        assert_eq!(counts.get(&(7000, TcpState::CloseWait)), Some(&14));
     }
 
     #[test]

--- a/src/doctor.rs
+++ b/src/doctor.rs
@@ -29,7 +29,7 @@ impl Severity {
 }
 
 #[derive(Debug, Clone)]
-struct Diagnostic {
+pub(crate) struct Diagnostic {
     severity: Severity,
     check: &'static str,
     title: String,
@@ -38,7 +38,7 @@ struct Diagnostic {
 
 /// Tracks which check categories were run (for rendering pass/skip).
 #[derive(Default)]
-struct CheckResults {
+pub(crate) struct CheckResults {
     port_conflicts: bool,
     wildcard_exposure: bool,
     docker_host_conflicts: bool,
@@ -195,34 +195,82 @@ fn render_diagnostics_json(w: &mut impl Write, diagnostics: &[Diagnostic]) {
 
 // ── Orchestrator ────────────────────────────────────────────────────
 
-/// Run every check and return the findings. Pure — no I/O, no exit — so that
-/// both the CLI renderer and MCP mode can drive it.
-fn collect_diagnostics() -> (Vec<Diagnostic>, CheckResults) {
-    let ports = get_port_infos(false);
-    let docker_map = get_docker_port_map();
-    let docker_available = !docker_map.is_empty();
+/// Everything the checks need, decoupled from where it was gathered.
+///
+/// The local collectors and the agentless SSH probe produce the same shapes, so
+/// a remote host can be diagnosed with the identical checks rather than a second
+/// implementation that drifts.
+pub(crate) struct Evidence {
+    pub ports: Vec<PortInfo>,
+    pub stale_counts: HashMap<(u16, TcpState), u32>,
+    /// `None` when Docker could not be inspected — which is different from an
+    /// empty map, and is why the Docker check reports "skipped" rather than
+    /// "passed" for a remote host.
+    pub docker: Option<DockerPortMap>,
+}
 
+impl Evidence {
+    /// Gather from the machine portview is running on.
+    fn local() -> Self {
+        let docker = get_docker_port_map();
+        Self {
+            ports: get_port_infos(false),
+            stale_counts: get_stale_connection_counts(),
+            docker: if docker.is_empty() {
+                None
+            } else {
+                Some(docker)
+            },
+        }
+    }
+}
+
+/// Run every check against gathered evidence. Pure — no I/O, no exit — so the
+/// CLI renderer, MCP mode, and remote diagnosis can all drive it.
+pub(crate) fn diagnose(evidence: &Evidence) -> (Vec<Diagnostic>, CheckResults) {
     let mut diagnostics = Vec::new();
     let mut results = CheckResults::default();
 
-    diagnostics.extend(check_port_conflicts(&ports));
+    diagnostics.extend(check_port_conflicts(&evidence.ports));
     results.port_conflicts = true;
 
-    diagnostics.extend(check_wildcard_exposure(&ports));
+    diagnostics.extend(check_wildcard_exposure(&evidence.ports));
     results.wildcard_exposure = true;
 
-    if docker_available {
-        diagnostics.extend(check_docker_host_conflicts(&ports, &docker_map));
+    if let Some(docker_map) = &evidence.docker {
+        diagnostics.extend(check_docker_host_conflicts(&evidence.ports, docker_map));
         results.docker_host_conflicts = true;
     }
 
-    diagnostics.extend(check_stale_connections(&get_stale_connection_counts()));
+    diagnostics.extend(check_stale_connections(&evidence.stale_counts));
     results.stale_connections = true;
 
-    diagnostics.extend(check_resource_hogs(&ports));
+    diagnostics.extend(check_resource_hogs(&evidence.ports));
     results.resource_hogs = true;
 
     (diagnostics, results)
+}
+
+fn collect_diagnostics() -> (Vec<Diagnostic>, CheckResults) {
+    diagnose(&Evidence::local())
+}
+
+/// Render a diagnosis. Returns true when anything error-severity was found, so
+/// the caller decides the exit code — a remote diagnosis should not call
+/// `process::exit` from inside a rendering helper.
+pub(crate) fn render(
+    diagnostics: &[Diagnostic],
+    results: &CheckResults,
+    use_color: bool,
+    json: bool,
+) -> bool {
+    let mut out = io::stdout().lock();
+    if json {
+        render_diagnostics_json(&mut out, diagnostics);
+    } else {
+        render_diagnostics(&mut out, diagnostics, results, use_color);
+    }
+    diagnostics.iter().any(|d| d.severity == Severity::Error)
 }
 
 /// Diagnostics as a JSON array string. Used by MCP mode, which cannot let
@@ -237,16 +285,7 @@ pub(crate) fn diagnostics_json_string() -> String {
 
 pub fn run_doctor(use_color: bool, json: bool) {
     let (diagnostics, results) = collect_diagnostics();
-    let has_errors = diagnostics.iter().any(|d| d.severity == Severity::Error);
-
-    let mut out = io::stdout().lock();
-    if json {
-        render_diagnostics_json(&mut out, &diagnostics);
-    } else {
-        render_diagnostics(&mut out, &diagnostics, &results, use_color);
-    }
-
-    if has_errors {
+    if render(&diagnostics, &results, use_color, json) {
         std::process::exit(1);
     }
 }

--- a/src/ssh.rs
+++ b/src/ssh.rs
@@ -143,15 +143,21 @@ pub(crate) fn run_ssh(
 
     let first_arg = remote_args.first().map(|s| s.as_str());
 
-    // watch and doctor both need portview on the far end: the TUI consumes a
-    // streaming JSON pipe, and doctor's checks run remotely.
-    if agentless && matches!(first_arg, Some("watch") | Some("doctor")) {
+    // watch still needs portview on the far end: the TUI consumes a streaming
+    // JSON pipe. doctor does not — its checks are pure functions over collected
+    // data, so they run locally against what the probe brought back.
+    if agentless && first_arg == Some("watch") {
         eprintln!(
-            "--agentless supports scans only; `{}` needs portview installed on {}.",
-            first_arg.unwrap_or(""),
+            "--agentless does not support `watch`; it needs portview installed on {}.",
             destination
         );
         std::process::exit(1);
+    }
+
+    if agentless && first_arg == Some("doctor") {
+        let json = remote_args.iter().any(|a| a == "--json");
+        run_agentless_doctor(&ssh, use_color, json);
+        return;
     }
 
     match first_arg {
@@ -174,6 +180,33 @@ pub(crate) fn run_ssh(
             }
             run_ssh_scan(&ssh, &args, use_color, agentless);
         }
+    }
+}
+
+/// Diagnose a remote host without portview installed on it.
+///
+/// The probe brings back the same shapes the local collectors produce, so the
+/// identical checks run here rather than a second implementation that drifts.
+fn run_agentless_doctor(ssh: &SshCommand, use_color: bool, json: bool) {
+    let ports = match ssh.run_agentless() {
+        Ok(p) => p,
+        Err(e) => {
+            eprintln!("{}", e);
+            std::process::exit(1);
+        }
+    };
+
+    let evidence = crate::doctor::Evidence {
+        stale_counts: crate::agentless::stale_counts(&ports),
+        ports,
+        // The probe does not query Docker on the far end, so the Docker check
+        // is reported as skipped rather than silently passing on no data.
+        docker: None,
+    };
+
+    let (diagnostics, results) = crate::doctor::diagnose(&evidence);
+    if crate::doctor::render(&diagnostics, &results, use_color, json) {
+        std::process::exit(1);
     }
 }
 


### PR DESCRIPTION
`portview ssh <host> doctor --agentless` now works. Agentless mode previously refused doctor outright, which left the strongest claim in the project carrying an asterisk: you could *scan* any box you can SSH to, but not *diagnose* it.

## Approach

doctor's checks are pure functions over collected data — nothing about them needs to run remotely. This separates *what is checked* from *where the data came from*:

```rust
struct Evidence { ports, stale_counts, docker }
fn diagnose(&Evidence) -> (Vec<Diagnostic>, CheckResults)
```

The local collectors and the SSH probe both produce that shape, so a remote host is diagnosed by the **identical checks** rather than a second implementation that drifts.

## Verified against ground truth

Same host, both paths:

```
=== local doctor ===                        === agentless over SSH ===
  ✓ No port conflicts                         ✓ No port conflicts
  ✓ No wildcard exposure issues               ✓ No wildcard exposure issues
  ! Port 7000 has 16 CLOSE_WAIT connections   ! Port 7000 has 16 CLOSE_WAIT connections
  ! node (PID 6) … using 1.2 GB of memory     ! node (PID 6) … using 1.2 GB of memory
  2 warnings found                            2 warnings found
```

Character-for-character identical, with portview genuinely absent from the far end (the test shim scrubs PATH).

## Two details worth review

**`docker` is `Option`, not an empty map.** "Not inspected" and "no containers" are different states — the probe doesn't query Docker remotely, so that check reports as *skipped* rather than silently passing on absent data.

**The agentless collector had the same connection-dedup bug** just fixed locally in #59. Collapsing non-LISTEN rows by `(port, protocol, pid)` turned a 16-socket `CLOSE_WAIT` pile-up into one row — which would have made remote leak detection impossible, since it counts exactly those rows. Fixed, with a test that a pile-up survives collection intact.

`watch` still needs portview remotely (the TUI consumes a streaming JSON pipe) and now says so specifically instead of lumping itself in with doctor.

168 tests, `fmt` and `clippy -D warnings` clean, macOS and Windows type-check.

Part of Tier 2. Remaining: lsof fallback for macOS/BSD remotes (#50), and agentless `watch`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)