### PR TITLE
fix(windows): avoid panic converting far-future FILETIME values

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,15 +102,21 @@ jobs:
           - target: x86_64-unknown-linux-gnu
             os: ubuntu-latest
             name: linux-x86_64
+            # Covered by the `quality` job, which runs the suite on Linux.
+            test: false
           - target: x86_64-apple-darwin
             os: macos-14
             name: darwin-x86_64
+            # Cross-compiled on an arm64 runner; binaries are not runnable here.
+            test: false
           - target: aarch64-apple-darwin
             os: macos-14
             name: darwin-aarch64
+            test: true
           - target: x86_64-pc-windows-msvc
             os: windows-latest
             name: windows-x86_64
+            test: true
 
     runs-on: ${{ matrix.os }}
 
@@ -129,6 +135,13 @@ jobs:
 
       - name: Build
         run: cargo build --release --target ${{ matrix.target }}
+
+      # The platform modules (src/windows.rs, src/macos.rs) are `#[cfg]`-gated,
+      # so their tests cannot run in the Linux-only `quality` job. Without this
+      # they are compiled but never executed on any runner.
+      - name: Test
+        if: matrix.test
+        run: cargo test --target ${{ matrix.target }}
 
       - name: Smoke test (Unix)
         if: runner.os != 'Windows'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,17 @@
 
 ### Fixed
 
+**A far-future process creation time panicked the scan on Windows.** Converting
+a `FILETIME` used `UNIX_EPOCH + Duration`, which panics when the result is
+unrepresentable. A Windows `SystemTime` is itself `FILETIME`-backed and ends
+near year 30828, so a garbage creation time overflowed it and aborted the run.
+It now returns `None`, which callers already handle.
+
+The test suite could not have caught this: `cargo test` ran only in the Linux
+`quality` job, so the `#[cfg(windows)]` and `#[cfg(macos)]` test modules were
+compiled but never executed on any runner. CI now runs the suite on the
+natively-runnable platform targets as well. Reported by @Guflly.
+
 **Ports whose owner could not be resolved were hidden entirely.** This is the
 worst failure mode for a port viewer: it reported a port as free when something
 was listening on it. On a normal Linux user account, `ss -tlnH` showed a

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -295,7 +295,10 @@ fn filetime_to_system_time(ft_low: u32, ft_high: u32) -> Option<SystemTime> {
     let unix_100ns = ticks - FILETIME_UNIX_OFFSET;
     let secs = unix_100ns / 10_000_000;
     let nanos = ((unix_100ns % 10_000_000) * 100) as u32;
-    Some(UNIX_EPOCH + Duration::new(secs, nanos))
+    // `UNIX_EPOCH + Duration` panics when the result is unrepresentable. On
+    // Windows a SystemTime is FILETIME-backed and tops out near year 30828,
+    // which a garbage or maliciously-large creation time overshoots easily.
+    UNIX_EPOCH.checked_add(Duration::new(secs, nanos))
 }
 
 fn get_process_name_and_path(handle: HANDLE) -> (String, String) {
@@ -654,9 +657,10 @@ mod tests {
 
     #[test]
     fn filetime_to_system_time_far_future_no_panic() {
-        // Should not panic even with very large values
-        let result = filetime_to_system_time(u32::MAX, u32::MAX);
-        assert!(result.is_some());
+        // Beyond the Windows SystemTime range, so this is None here — the
+        // contract being tested is that it returns rather than panicking.
+        // Asserting is_some() was what made this test panic instead of fail.
+        assert_eq!(filetime_to_system_time(u32::MAX, u32::MAX), None);
     }
 
     #[test]


### PR DESCRIPTION
Found while reviewing #60 — @Guflly noted in passing that "the full Windows suite still hits the existing far-future FILETIME panic on `main`." They are right, and the reason it survived this long is the more interesting half.

## The panic

```rust
Some(UNIX_EPOCH + Duration::new(secs, nanos))
```

`Add` for `SystemTime` panics when the result is unrepresentable. `filetime_to_u64(u32::MAX, u32::MAX)` is `u64::MAX`, which works out to roughly year 58,000. A Windows `SystemTime` is itself `FILETIME`-backed and ends near year 30828, so it overflows and takes the whole scan down.

Linux never sees it: `SystemTime` there is a timespec with i64 seconds, which swallows the value happily. That platform split is exactly why a test named `filetime_to_system_time_far_future_no_panic` has been sitting there green.

Fixed with `checked_add`. The function already returns `Option` and callers already handle `None`, so nothing downstream changes.

## Why no test caught it

`cargo test` runs **only in the Linux `quality` job**. The platform matrix jobs run `cargo build --release --target ...` and a smoke test — no tests. So every `#[cfg(windows)]` and `#[cfg(macos)]` test in the repo has been compiled and never executed, on any runner.

This PR runs the suite on the platform targets that are natively runnable:

| target | runs tests | why |
| --- | --- | --- |
| `x86_64-unknown-linux-gnu` | no | already covered by `quality` |
| `x86_64-apple-darwin` | no | cross-compiled on an arm64 runner, not runnable |
| `aarch64-apple-darwin` | yes | native |
| `x86_64-pc-windows-msvc` | yes | native |

The old assertion was `assert!(result.is_some())` — asserting the very thing that overflows, which is what made this a panic rather than a failure. It now asserts `None`, the correct Windows answer.

## Verification

`cargo fmt`, `clippy -D warnings`, 169 tests, and both cross-target checks pass locally. But a `#[cfg(windows)]` fix cannot be genuinely verified from Linux — **the CI change is the verification**. If the Windows job goes green here, it is the first time these tests have ever run.
