### PR TITLE
chore: release 2.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,22 @@
 # Changelog
 
-## Unreleased
+## 2.1.0
+
+Agentless SSH now covers every command, so any host you can reach over SSH can
+be scanned, inspected, diagnosed, and watched without installing anything on
+it. The MCP server gained a change-diff tool, descendant processes, and a dry
+run for the one destructive tool it offers.
+
+**If you script against portview, three outputs changed.** All three are
+corrections of wrong behaviour rather than redefinitions, but a script pinned to
+2.0.x will see different results:
+
+- Ports whose owner cannot be resolved are now listed with `-` instead of being
+  omitted, so a scan can return rows it did not before.
+- `--all` emits one row per connection rather than collapsing them, so a port
+  with sixty `TIME_WAIT` sockets is now sixty rows.
+- `portview ssh <host> --json` emits JSON. It previously either printed a table
+  or failed outright, so nothing could have depended on the old behaviour.
 
 ### Added
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -973,7 +973,7 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portview"
-version = "2.0.2"
+version = "2.1.0"
 dependencies = [
  "clap",
  "clap_complete",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "portview"
-version = "2.0.2"
+version = "2.1.0"
 edition = "2024"
 description = "A diagnostic-first port viewer. See what's on your ports, then act on it."
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -96,10 +96,11 @@ Or configure it manually:
 | Tool | What it does |
 |------|--------------|
 | `list_ports` | Every listening port with process, user, uptime, memory, full command |
-| `inspect_port` | One port in detail, including each process's working directory |
+| `inspect_port` | One port in detail: each process's working directory, plus its child processes — so the agent knows what else stops when it stops your dev server |
 | `find_process` | Which ports a service is on, by name or command substring |
 | `doctor` | Conflicts, wildcard exposure, stale connections, resource hogs |
-| `kill_port` | Terminate what's on a port (marked destructive to the client) |
+| `diff_ports` | What opened, closed, or changed owner since a baseline — "what did starting that actually do?" |
+| `kill_port` | Terminate what's on a port (marked destructive to the client). `dry_run` shows which PIDs it would signal, without signalling them |
 
 <p align="center">
   <img src="demo/mcp.gif" alt="portview MCP server demo" width="100%" loop=infinite>

--- a/flake.nix
+++ b/flake.nix
@@ -15,7 +15,7 @@
         packages = rec {
           portview = pkgs.rustPlatform.buildRustPackage {
             pname = "portview";
-            version = "2.0.2";
+            version = "2.1.0";
 
             src = self;
 

--- a/server.json
+++ b/server.json
@@ -8,12 +8,12 @@
     "source": "github"
   },
   "websiteUrl": "https://github.com/Mapika/portview",
-  "version": "2.0.2",
+  "version": "2.1.0",
   "packages": [
     {
       "registryType": "cargo",
       "identifier": "portview",
-      "version": "2.0.2",
+      "version": "2.1.0",
       "transport": {
         "type": "stdio"
       },


### PR DESCRIPTION
Version bump across the four places the release workflow cross-checks against the tag: `Cargo.toml`, `flake.nix`, `server.json`, and `Cargo.lock`. All read 2.1.0, and the built binary reports `portview 2.1.0`.

## Why 2.1.0 and not 3.0.0

Nothing intentionally breaks a documented contract. New features are additive, and the behaviour changes are corrections of output that was wrong — the most serious being that portview could report a port as free while something was listening on it.

That said, three outputs genuinely differ from 2.0.x, and the changelog now says so up front rather than burying it in the Fixed section, because a pinned script will notice:

- unresolvable-owner ports are listed with `-` instead of omitted — a scan can return rows it did not before
- `--all` emits one row per connection, so sixty `TIME_WAIT` sockets are sixty rows
- `portview ssh <host> --json` emits JSON, having previously printed a table or failed outright

## Also here

The README's MCP tool table was stale — no `diff_ports`, no mention of `dry_run` or child processes. That table is the shop window for the registry listing, so it is worth being current.

## What's in the release

21 commits since 2.0.2.

**Agentless SSH now covers every command.** `doctor`, an `lsof` fallback for macOS and BSD remotes, and `watch` — the last over a single connection, with the interactive kill working without portview on the far end.

**MCP depth.** `diff_ports`, descendant processes in `inspect_port`, and `dry_run` on `kill_port`.

**Fixes**, in rough order of severity: ports with unresolvable owners were hidden entirely; a far-future `FILETIME` panicked the scan on Windows; `portview ssh --json` never worked; `--all` collapsed connections and so contradicted `doctor`.

**CI now runs the test suite on Windows and macOS.** It only ever ran on Linux, so every `#[cfg(windows)]` and `#[cfg(macos)]` test had been compiled and never executed. That is how the `FILETIME` panic survived behind a test named `..._far_future_no_panic`.

Plus a first outside contribution from @Guflly (#60), who also spotted the `FILETIME` bug.

## Before tagging

I have not tagged. crates.io versions are immutable — that is what cost us 2.0.1 and 2.0.2 — so the tag is yours to push once this looks right:

```bash
git tag v2.1.0 && git push origin v2.1.0
git tag -f v2 && git push -f origin v2    # the moving major tag users pin
```

196 tests, fmt/clippy clean, macOS + Windows type-check.
